### PR TITLE
v6.12.2

### DIFF
--- a/addmultisigaddress.html
+++ b/addmultisigaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - addmultisigaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - addmultisigaddress">
     <meta name="author" content="">
-    <title>addmultisigaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>addmultisigaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addmultisigaddress - Zcash 6.2.0 RPC</h1>
+            <h1>addmultisigaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>addmultisigaddress nrequired [&#34;key&#34;,...] ( &#34;&#34; )
 

--- a/addmultisigaddress.html
+++ b/addmultisigaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - addmultisigaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - addmultisigaddress">
     <meta name="author" content="">
-    <title>addmultisigaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>addmultisigaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addmultisigaddress - Zcash 6.10.0 RPC</h1>
+            <h1>addmultisigaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>addmultisigaddress nrequired [&#34;key&#34;,...] ( &#34;&#34; )
 

--- a/addmultisigaddress.html
+++ b/addmultisigaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - addmultisigaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - addmultisigaddress">
     <meta name="author" content="">
-    <title>addmultisigaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>addmultisigaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addmultisigaddress - Zcash 6.12.1 RPC</h1>
+            <h1>addmultisigaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>addmultisigaddress nrequired [&#34;key&#34;,...] ( &#34;&#34; )
 

--- a/addnode.html
+++ b/addnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - addnode">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - addnode">
     <meta name="author" content="">
-    <title>addnode - Zcash 6.12.1 RPC Docs</title>
+    <title>addnode - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addnode - Zcash 6.12.1 RPC</h1>
+            <h1>addnode - Zcash 6.12.2 RPC</h1>
           
             <pre>addnode &#34;node&#34; &#34;add|remove|onetry&#34;
 

--- a/addnode.html
+++ b/addnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - addnode">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - addnode">
     <meta name="author" content="">
-    <title>addnode - Zcash 6.10.0 RPC Docs</title>
+    <title>addnode - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addnode - Zcash 6.10.0 RPC</h1>
+            <h1>addnode - Zcash 6.12.1 RPC</h1>
           
             <pre>addnode &#34;node&#34; &#34;add|remove|onetry&#34;
 

--- a/addnode.html
+++ b/addnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - addnode">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - addnode">
     <meta name="author" content="">
-    <title>addnode - Zcash 6.2.0 RPC Docs</title>
+    <title>addnode - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>addnode - Zcash 6.2.0 RPC</h1>
+            <h1>addnode - Zcash 6.10.0 RPC</h1>
           
             <pre>addnode &#34;node&#34; &#34;add|remove|onetry&#34;
 

--- a/backupwallet.html
+++ b/backupwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - backupwallet">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - backupwallet">
     <meta name="author" content="">
-    <title>backupwallet - Zcash 6.12.1 RPC Docs</title>
+    <title>backupwallet - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>backupwallet - Zcash 6.12.1 RPC</h1>
+            <h1>backupwallet - Zcash 6.12.2 RPC</h1>
           
             <pre>backupwallet &#34;destination&#34;
 

--- a/backupwallet.html
+++ b/backupwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - backupwallet">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - backupwallet">
     <meta name="author" content="">
-    <title>backupwallet - Zcash 6.10.0 RPC Docs</title>
+    <title>backupwallet - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>backupwallet - Zcash 6.10.0 RPC</h1>
+            <h1>backupwallet - Zcash 6.12.1 RPC</h1>
           
             <pre>backupwallet &#34;destination&#34;
 

--- a/backupwallet.html
+++ b/backupwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - backupwallet">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - backupwallet">
     <meta name="author" content="">
-    <title>backupwallet - Zcash 6.2.0 RPC Docs</title>
+    <title>backupwallet - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>backupwallet - Zcash 6.2.0 RPC</h1>
+            <h1>backupwallet - Zcash 6.10.0 RPC</h1>
           
             <pre>backupwallet &#34;destination&#34;
 

--- a/clearbanned.html
+++ b/clearbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - clearbanned">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - clearbanned">
     <meta name="author" content="">
-    <title>clearbanned - Zcash 6.2.0 RPC Docs</title>
+    <title>clearbanned - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>clearbanned - Zcash 6.2.0 RPC</h1>
+            <h1>clearbanned - Zcash 6.10.0 RPC</h1>
           
             <pre>clearbanned
 

--- a/clearbanned.html
+++ b/clearbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - clearbanned">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - clearbanned">
     <meta name="author" content="">
-    <title>clearbanned - Zcash 6.10.0 RPC Docs</title>
+    <title>clearbanned - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>clearbanned - Zcash 6.10.0 RPC</h1>
+            <h1>clearbanned - Zcash 6.12.1 RPC</h1>
           
             <pre>clearbanned
 

--- a/clearbanned.html
+++ b/clearbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - clearbanned">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - clearbanned">
     <meta name="author" content="">
-    <title>clearbanned - Zcash 6.12.1 RPC Docs</title>
+    <title>clearbanned - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>clearbanned - Zcash 6.12.1 RPC</h1>
+            <h1>clearbanned - Zcash 6.12.2 RPC</h1>
           
             <pre>clearbanned
 

--- a/createmultisig.html
+++ b/createmultisig.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - createmultisig">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - createmultisig">
     <meta name="author" content="">
-    <title>createmultisig - Zcash 6.2.0 RPC Docs</title>
+    <title>createmultisig - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createmultisig - Zcash 6.2.0 RPC</h1>
+            <h1>createmultisig - Zcash 6.10.0 RPC</h1>
           
             <pre>createmultisig nrequired [&#34;key&#34;,...]
 

--- a/createmultisig.html
+++ b/createmultisig.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - createmultisig">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - createmultisig">
     <meta name="author" content="">
-    <title>createmultisig - Zcash 6.12.1 RPC Docs</title>
+    <title>createmultisig - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createmultisig - Zcash 6.12.1 RPC</h1>
+            <h1>createmultisig - Zcash 6.12.2 RPC</h1>
           
             <pre>createmultisig nrequired [&#34;key&#34;,...]
 

--- a/createmultisig.html
+++ b/createmultisig.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - createmultisig">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - createmultisig">
     <meta name="author" content="">
-    <title>createmultisig - Zcash 6.10.0 RPC Docs</title>
+    <title>createmultisig - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createmultisig - Zcash 6.10.0 RPC</h1>
+            <h1>createmultisig - Zcash 6.12.1 RPC</h1>
           
             <pre>createmultisig nrequired [&#34;key&#34;,...]
 

--- a/createrawtransaction.html
+++ b/createrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - createrawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - createrawtransaction">
     <meta name="author" content="">
-    <title>createrawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>createrawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createrawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>createrawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>createrawtransaction [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n},...] {&#34;address&#34;:amount,...} ( locktime ) ( expiryheight )
 

--- a/createrawtransaction.html
+++ b/createrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - createrawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - createrawtransaction">
     <meta name="author" content="">
-    <title>createrawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>createrawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createrawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>createrawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>createrawtransaction [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n},...] {&#34;address&#34;:amount,...} ( locktime ) ( expiryheight )
 

--- a/createrawtransaction.html
+++ b/createrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - createrawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - createrawtransaction">
     <meta name="author" content="">
-    <title>createrawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>createrawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>createrawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>createrawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>createrawtransaction [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n},...] {&#34;address&#34;:amount,...} ( locktime ) ( expiryheight )
 

--- a/decoderawtransaction.html
+++ b/decoderawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - decoderawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - decoderawtransaction">
     <meta name="author" content="">
-    <title>decoderawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>decoderawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decoderawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>decoderawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>decoderawtransaction &#34;hexstring&#34;
 

--- a/decoderawtransaction.html
+++ b/decoderawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - decoderawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - decoderawtransaction">
     <meta name="author" content="">
-    <title>decoderawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>decoderawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decoderawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>decoderawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>decoderawtransaction &#34;hexstring&#34;
 

--- a/decoderawtransaction.html
+++ b/decoderawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - decoderawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - decoderawtransaction">
     <meta name="author" content="">
-    <title>decoderawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>decoderawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decoderawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>decoderawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>decoderawtransaction &#34;hexstring&#34;
 

--- a/decodescript.html
+++ b/decodescript.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - decodescript">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - decodescript">
     <meta name="author" content="">
-    <title>decodescript - Zcash 6.12.1 RPC Docs</title>
+    <title>decodescript - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decodescript - Zcash 6.12.1 RPC</h1>
+            <h1>decodescript - Zcash 6.12.2 RPC</h1>
           
             <pre>decodescript &#34;hex&#34;
 

--- a/decodescript.html
+++ b/decodescript.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - decodescript">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - decodescript">
     <meta name="author" content="">
-    <title>decodescript - Zcash 6.10.0 RPC Docs</title>
+    <title>decodescript - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decodescript - Zcash 6.10.0 RPC</h1>
+            <h1>decodescript - Zcash 6.12.1 RPC</h1>
           
             <pre>decodescript &#34;hex&#34;
 

--- a/decodescript.html
+++ b/decodescript.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - decodescript">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - decodescript">
     <meta name="author" content="">
-    <title>decodescript - Zcash 6.2.0 RPC Docs</title>
+    <title>decodescript - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>decodescript - Zcash 6.2.0 RPC</h1>
+            <h1>decodescript - Zcash 6.10.0 RPC</h1>
           
             <pre>decodescript &#34;hex&#34;
 

--- a/disconnectnode.html
+++ b/disconnectnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - disconnectnode">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - disconnectnode">
     <meta name="author" content="">
-    <title>disconnectnode - Zcash 6.12.1 RPC Docs</title>
+    <title>disconnectnode - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>disconnectnode - Zcash 6.12.1 RPC</h1>
+            <h1>disconnectnode - Zcash 6.12.2 RPC</h1>
           
             <pre>disconnectnode &#34;node&#34; 
 

--- a/disconnectnode.html
+++ b/disconnectnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - disconnectnode">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - disconnectnode">
     <meta name="author" content="">
-    <title>disconnectnode - Zcash 6.10.0 RPC Docs</title>
+    <title>disconnectnode - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>disconnectnode - Zcash 6.10.0 RPC</h1>
+            <h1>disconnectnode - Zcash 6.12.1 RPC</h1>
           
             <pre>disconnectnode &#34;node&#34; 
 

--- a/disconnectnode.html
+++ b/disconnectnode.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - disconnectnode">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - disconnectnode">
     <meta name="author" content="">
-    <title>disconnectnode - Zcash 6.2.0 RPC Docs</title>
+    <title>disconnectnode - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>disconnectnode - Zcash 6.2.0 RPC</h1>
+            <h1>disconnectnode - Zcash 6.10.0 RPC</h1>
           
             <pre>disconnectnode &#34;node&#34; 
 

--- a/dumpprivkey.html
+++ b/dumpprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - dumpprivkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - dumpprivkey">
     <meta name="author" content="">
-    <title>dumpprivkey - Zcash 6.12.1 RPC Docs</title>
+    <title>dumpprivkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>dumpprivkey - Zcash 6.12.1 RPC</h1>
+            <h1>dumpprivkey - Zcash 6.12.2 RPC</h1>
           
             <pre>dumpprivkey &#34;t-addr&#34;
 

--- a/dumpprivkey.html
+++ b/dumpprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - dumpprivkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - dumpprivkey">
     <meta name="author" content="">
-    <title>dumpprivkey - Zcash 6.10.0 RPC Docs</title>
+    <title>dumpprivkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>dumpprivkey - Zcash 6.10.0 RPC</h1>
+            <h1>dumpprivkey - Zcash 6.12.1 RPC</h1>
           
             <pre>dumpprivkey &#34;t-addr&#34;
 

--- a/dumpprivkey.html
+++ b/dumpprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - dumpprivkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - dumpprivkey">
     <meta name="author" content="">
-    <title>dumpprivkey - Zcash 6.2.0 RPC Docs</title>
+    <title>dumpprivkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>dumpprivkey - Zcash 6.2.0 RPC</h1>
+            <h1>dumpprivkey - Zcash 6.10.0 RPC</h1>
           
             <pre>dumpprivkey &#34;t-addr&#34;
 

--- a/encryptwallet.html
+++ b/encryptwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - encryptwallet">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - encryptwallet">
     <meta name="author" content="">
-    <title>encryptwallet - Zcash 6.2.0 RPC Docs</title>
+    <title>encryptwallet - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>encryptwallet - Zcash 6.2.0 RPC</h1>
+            <h1>encryptwallet - Zcash 6.10.0 RPC</h1>
           
             <pre>encryptwallet &#34;passphrase&#34;
 

--- a/encryptwallet.html
+++ b/encryptwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - encryptwallet">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - encryptwallet">
     <meta name="author" content="">
-    <title>encryptwallet - Zcash 6.10.0 RPC Docs</title>
+    <title>encryptwallet - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>encryptwallet - Zcash 6.10.0 RPC</h1>
+            <h1>encryptwallet - Zcash 6.12.1 RPC</h1>
           
             <pre>encryptwallet &#34;passphrase&#34;
 

--- a/encryptwallet.html
+++ b/encryptwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - encryptwallet">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - encryptwallet">
     <meta name="author" content="">
-    <title>encryptwallet - Zcash 6.12.1 RPC Docs</title>
+    <title>encryptwallet - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>encryptwallet - Zcash 6.12.1 RPC</h1>
+            <h1>encryptwallet - Zcash 6.12.2 RPC</h1>
           
             <pre>encryptwallet &#34;passphrase&#34;
 

--- a/fundrawtransaction.html
+++ b/fundrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - fundrawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - fundrawtransaction">
     <meta name="author" content="">
-    <title>fundrawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>fundrawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>fundrawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>fundrawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>fundrawtransaction &#34;hexstring&#34; includeWatching
 

--- a/fundrawtransaction.html
+++ b/fundrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - fundrawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - fundrawtransaction">
     <meta name="author" content="">
-    <title>fundrawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>fundrawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>fundrawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>fundrawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>fundrawtransaction &#34;hexstring&#34; includeWatching
 

--- a/fundrawtransaction.html
+++ b/fundrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - fundrawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - fundrawtransaction">
     <meta name="author" content="">
-    <title>fundrawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>fundrawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>fundrawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>fundrawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>fundrawtransaction &#34;hexstring&#34; includeWatching
 

--- a/generate.html
+++ b/generate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - generate">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - generate">
     <meta name="author" content="">
-    <title>generate - Zcash 6.2.0 RPC Docs</title>
+    <title>generate - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>generate - Zcash 6.2.0 RPC</h1>
+            <h1>generate - Zcash 6.10.0 RPC</h1>
           
             <pre>generate numblocks
 

--- a/generate.html
+++ b/generate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - generate">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - generate">
     <meta name="author" content="">
-    <title>generate - Zcash 6.12.1 RPC Docs</title>
+    <title>generate - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>generate - Zcash 6.12.1 RPC</h1>
+            <h1>generate - Zcash 6.12.2 RPC</h1>
           
             <pre>generate numblocks
 

--- a/generate.html
+++ b/generate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - generate">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - generate">
     <meta name="author" content="">
-    <title>generate - Zcash 6.10.0 RPC Docs</title>
+    <title>generate - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>generate - Zcash 6.10.0 RPC</h1>
+            <h1>generate - Zcash 6.12.1 RPC</h1>
           
             <pre>generate numblocks
 

--- a/getaddednodeinfo.html
+++ b/getaddednodeinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddednodeinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddednodeinfo">
     <meta name="author" content="">
-    <title>getaddednodeinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddednodeinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddednodeinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getaddednodeinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddednodeinfo dns ( &#34;node&#34; )
 

--- a/getaddednodeinfo.html
+++ b/getaddednodeinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddednodeinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddednodeinfo">
     <meta name="author" content="">
-    <title>getaddednodeinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddednodeinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddednodeinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getaddednodeinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddednodeinfo dns ( &#34;node&#34; )
 

--- a/getaddednodeinfo.html
+++ b/getaddednodeinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddednodeinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddednodeinfo">
     <meta name="author" content="">
-    <title>getaddednodeinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddednodeinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddednodeinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getaddednodeinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddednodeinfo dns ( &#34;node&#34; )
 

--- a/getaddressbalance.html
+++ b/getaddressbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddressbalance">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressbalance">
     <meta name="author" content="">
-    <title>getaddressbalance - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddressbalance - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,33 +23,18 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressbalance - Zcash 6.2.0 RPC</h1>
+            <h1>getaddressbalance - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddressbalance {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 
 Returns the balance for addresses.
-
-WARNING: getaddressbalance is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 {

--- a/getaddressbalance.html
+++ b/getaddressbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressbalance">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddressbalance">
     <meta name="author" content="">
-    <title>getaddressbalance - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddressbalance - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressbalance - Zcash 6.12.1 RPC</h1>
+            <h1>getaddressbalance - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddressbalance {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 

--- a/getaddressbalance.html
+++ b/getaddressbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressbalance">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressbalance">
     <meta name="author" content="">
-    <title>getaddressbalance - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddressbalance - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressbalance - Zcash 6.10.0 RPC</h1>
+            <h1>getaddressbalance - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddressbalance {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 

--- a/getaddressdeltas.html
+++ b/getaddressdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressdeltas">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddressdeltas">
     <meta name="author" content="">
-    <title>getaddressdeltas - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddressdeltas - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressdeltas - Zcash 6.12.1 RPC</h1>
+            <h1>getaddressdeltas - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddressdeltas {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n), (&#34;chainInfo&#34;: true|false)}
 

--- a/getaddressdeltas.html
+++ b/getaddressdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddressdeltas">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressdeltas">
     <meta name="author" content="">
-    <title>getaddressdeltas - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddressdeltas - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressdeltas - Zcash 6.2.0 RPC</h1>
+            <h1>getaddressdeltas - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddressdeltas {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n), (&#34;chainInfo&#34;: true|false)}
 
@@ -43,21 +43,6 @@ If start or end are not specified, they default to zero.
 If start is greater than the latest block height, it&#39;s interpreted as that height.
 
 If end is zero, it&#39;s interpreted as the latest block height.
-
-WARNING: getaddressdeltas is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 {

--- a/getaddressdeltas.html
+++ b/getaddressdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressdeltas">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressdeltas">
     <meta name="author" content="">
-    <title>getaddressdeltas - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddressdeltas - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressdeltas - Zcash 6.10.0 RPC</h1>
+            <h1>getaddressdeltas - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddressdeltas {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n), (&#34;chainInfo&#34;: true|false)}
 

--- a/getaddressmempool.html
+++ b/getaddressmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddressmempool">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressmempool">
     <meta name="author" content="">
-    <title>getaddressmempool - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddressmempool - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,33 +23,18 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressmempool - Zcash 6.2.0 RPC</h1>
+            <h1>getaddressmempool - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddressmempool {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 
 Returns all mempool deltas for an address.
-
-WARNING: getaddressmempool is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 {

--- a/getaddressmempool.html
+++ b/getaddressmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressmempool">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressmempool">
     <meta name="author" content="">
-    <title>getaddressmempool - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddressmempool - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressmempool - Zcash 6.10.0 RPC</h1>
+            <h1>getaddressmempool - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddressmempool {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 

--- a/getaddressmempool.html
+++ b/getaddressmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressmempool">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddressmempool">
     <meta name="author" content="">
-    <title>getaddressmempool - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddressmempool - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressmempool - Zcash 6.12.1 RPC</h1>
+            <h1>getaddressmempool - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddressmempool {&#34;addresses&#34;: [&#34;taddr&#34;, ...]}
 

--- a/getaddresstxids.html
+++ b/getaddresstxids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddresstxids">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddresstxids">
     <meta name="author" content="">
-    <title>getaddresstxids - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddresstxids - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddresstxids - Zcash 6.10.0 RPC</h1>
+            <h1>getaddresstxids - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddresstxids {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n)}
 

--- a/getaddresstxids.html
+++ b/getaddresstxids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddresstxids">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddresstxids">
     <meta name="author" content="">
-    <title>getaddresstxids - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddresstxids - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddresstxids - Zcash 6.12.1 RPC</h1>
+            <h1>getaddresstxids - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddresstxids {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n)}
 

--- a/getaddresstxids.html
+++ b/getaddresstxids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddresstxids">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddresstxids">
     <meta name="author" content="">
-    <title>getaddresstxids - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddresstxids - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddresstxids - Zcash 6.2.0 RPC</h1>
+            <h1>getaddresstxids - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddresstxids {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;start&#34;: n), (&#34;end&#34;: n)}
 
@@ -45,21 +45,6 @@ If end is zero, it&#39;s interpreted as the latest block height.
 The returned txids are in the order they appear in blocks, which
 ensures that they are topologically sorted (i.e. parent txids
 appear before child txids).
-
-WARNING: getaddresstxids is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 {

--- a/getaddressutxos.html
+++ b/getaddressutxos.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getaddressutxos">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressutxos">
     <meta name="author" content="">
-    <title>getaddressutxos - Zcash 6.2.0 RPC Docs</title>
+    <title>getaddressutxos - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,33 +23,18 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressutxos - Zcash 6.2.0 RPC</h1>
+            <h1>getaddressutxos - Zcash 6.10.0 RPC</h1>
           
             <pre>getaddressutxos {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;chainInfo&#34;: true|false)}
 
 Returns all unspent outputs for an address.
-
-WARNING: getaddressutxos is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 {

--- a/getaddressutxos.html
+++ b/getaddressutxos.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressutxos">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getaddressutxos">
     <meta name="author" content="">
-    <title>getaddressutxos - Zcash 6.12.1 RPC Docs</title>
+    <title>getaddressutxos - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressutxos - Zcash 6.12.1 RPC</h1>
+            <h1>getaddressutxos - Zcash 6.12.2 RPC</h1>
           
             <pre>getaddressutxos {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;chainInfo&#34;: true|false)}
 

--- a/getaddressutxos.html
+++ b/getaddressutxos.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getaddressutxos">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getaddressutxos">
     <meta name="author" content="">
-    <title>getaddressutxos - Zcash 6.10.0 RPC Docs</title>
+    <title>getaddressutxos - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getaddressutxos - Zcash 6.10.0 RPC</h1>
+            <h1>getaddressutxos - Zcash 6.12.1 RPC</h1>
           
             <pre>getaddressutxos {&#34;addresses&#34;: [&#34;taddr&#34;, ...], (&#34;chainInfo&#34;: true|false)}
 

--- a/getbalance.html
+++ b/getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getbalance">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getbalance">
     <meta name="author" content="">
-    <title>getbalance - Zcash 6.2.0 RPC Docs</title>
+    <title>getbalance - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbalance - Zcash 6.2.0 RPC</h1>
+            <h1>getbalance - Zcash 6.10.0 RPC</h1>
           
             <pre>getbalance ( &#34;(dummy)&#34; minconf includeWatchonly inZat asOfHeight )
 

--- a/getbalance.html
+++ b/getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getbalance">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getbalance">
     <meta name="author" content="">
-    <title>getbalance - Zcash 6.12.1 RPC Docs</title>
+    <title>getbalance - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbalance - Zcash 6.12.1 RPC</h1>
+            <h1>getbalance - Zcash 6.12.2 RPC</h1>
           
             <pre>getbalance ( &#34;(dummy)&#34; minconf includeWatchonly inZat asOfHeight )
 

--- a/getbalance.html
+++ b/getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getbalance">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getbalance">
     <meta name="author" content="">
-    <title>getbalance - Zcash 6.10.0 RPC Docs</title>
+    <title>getbalance - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbalance - Zcash 6.10.0 RPC</h1>
+            <h1>getbalance - Zcash 6.12.1 RPC</h1>
           
             <pre>getbalance ( &#34;(dummy)&#34; minconf includeWatchonly inZat asOfHeight )
 

--- a/getbestblockhash.html
+++ b/getbestblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getbestblockhash">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getbestblockhash">
     <meta name="author" content="">
-    <title>getbestblockhash - Zcash 6.12.1 RPC Docs</title>
+    <title>getbestblockhash - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbestblockhash - Zcash 6.12.1 RPC</h1>
+            <h1>getbestblockhash - Zcash 6.12.2 RPC</h1>
           
             <pre>getbestblockhash
 

--- a/getbestblockhash.html
+++ b/getbestblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getbestblockhash">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getbestblockhash">
     <meta name="author" content="">
-    <title>getbestblockhash - Zcash 6.2.0 RPC Docs</title>
+    <title>getbestblockhash - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbestblockhash - Zcash 6.2.0 RPC</h1>
+            <h1>getbestblockhash - Zcash 6.10.0 RPC</h1>
           
             <pre>getbestblockhash
 

--- a/getbestblockhash.html
+++ b/getbestblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getbestblockhash">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getbestblockhash">
     <meta name="author" content="">
-    <title>getbestblockhash - Zcash 6.10.0 RPC Docs</title>
+    <title>getbestblockhash - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getbestblockhash - Zcash 6.10.0 RPC</h1>
+            <h1>getbestblockhash - Zcash 6.12.1 RPC</h1>
           
             <pre>getbestblockhash
 

--- a/getblock.html
+++ b/getblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblock">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblock">
     <meta name="author" content="">
-    <title>getblock - Zcash 6.2.0 RPC Docs</title>
+    <title>getblock - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblock - Zcash 6.2.0 RPC</h1>
+            <h1>getblock - Zcash 6.10.0 RPC</h1>
           
             <pre>getblock &#34;hash|height&#34; ( verbosity )
 

--- a/getblock.html
+++ b/getblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblock">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblock">
     <meta name="author" content="">
-    <title>getblock - Zcash 6.10.0 RPC Docs</title>
+    <title>getblock - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblock - Zcash 6.10.0 RPC</h1>
+            <h1>getblock - Zcash 6.12.1 RPC</h1>
           
             <pre>getblock &#34;hash|height&#34; ( verbosity )
 

--- a/getblock.html
+++ b/getblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblock">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblock">
     <meta name="author" content="">
-    <title>getblock - Zcash 6.12.1 RPC Docs</title>
+    <title>getblock - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblock - Zcash 6.12.1 RPC</h1>
+            <h1>getblock - Zcash 6.12.2 RPC</h1>
           
             <pre>getblock &#34;hash|height&#34; ( verbosity )
 

--- a/getblockchaininfo.html
+++ b/getblockchaininfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockchaininfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockchaininfo">
     <meta name="author" content="">
-    <title>getblockchaininfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockchaininfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockchaininfo - Zcash 6.2.0 RPC</h1>
+            <h1>getblockchaininfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockchaininfo
 Returns an object containing various state info regarding block chain processing.

--- a/getblockchaininfo.html
+++ b/getblockchaininfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockchaininfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockchaininfo">
     <meta name="author" content="">
-    <title>getblockchaininfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockchaininfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockchaininfo - Zcash 6.10.0 RPC</h1>
+            <h1>getblockchaininfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockchaininfo
 Returns an object containing various state info regarding block chain processing.

--- a/getblockchaininfo.html
+++ b/getblockchaininfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockchaininfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockchaininfo">
     <meta name="author" content="">
-    <title>getblockchaininfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockchaininfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockchaininfo - Zcash 6.12.1 RPC</h1>
+            <h1>getblockchaininfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockchaininfo
 Returns an object containing various state info regarding block chain processing.

--- a/getblockcount.html
+++ b/getblockcount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockcount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockcount">
     <meta name="author" content="">
-    <title>getblockcount - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockcount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockcount - Zcash 6.12.1 RPC</h1>
+            <h1>getblockcount - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockcount
 

--- a/getblockcount.html
+++ b/getblockcount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockcount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockcount">
     <meta name="author" content="">
-    <title>getblockcount - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockcount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockcount - Zcash 6.10.0 RPC</h1>
+            <h1>getblockcount - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockcount
 

--- a/getblockcount.html
+++ b/getblockcount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockcount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockcount">
     <meta name="author" content="">
-    <title>getblockcount - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockcount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockcount - Zcash 6.2.0 RPC</h1>
+            <h1>getblockcount - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockcount
 

--- a/getblockdeltas.html
+++ b/getblockdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockdeltas">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockdeltas">
     <meta name="author" content="">
-    <title>getblockdeltas - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockdeltas - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockdeltas - Zcash 6.10.0 RPC</h1>
+            <h1>getblockdeltas - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockdeltas &#34;blockhash&#34;
 

--- a/getblockdeltas.html
+++ b/getblockdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockdeltas">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockdeltas">
     <meta name="author" content="">
-    <title>getblockdeltas - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockdeltas - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,33 +23,18 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockdeltas - Zcash 6.2.0 RPC</h1>
+            <h1>getblockdeltas - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockdeltas &#34;blockhash&#34;
 
 Returns information about the given block and its transactions.
-
-WARNING: getblockdeltas is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 1. &#34;hash&#34;          (string, required) The block hash

--- a/getblockdeltas.html
+++ b/getblockdeltas.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockdeltas">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockdeltas">
     <meta name="author" content="">
-    <title>getblockdeltas - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockdeltas - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockdeltas - Zcash 6.12.1 RPC</h1>
+            <h1>getblockdeltas - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockdeltas &#34;blockhash&#34;
 

--- a/getblockhash.html
+++ b/getblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockhash">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockhash">
     <meta name="author" content="">
-    <title>getblockhash - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockhash - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhash - Zcash 6.2.0 RPC</h1>
+            <h1>getblockhash - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockhash index
 

--- a/getblockhash.html
+++ b/getblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockhash">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockhash">
     <meta name="author" content="">
-    <title>getblockhash - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockhash - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhash - Zcash 6.10.0 RPC</h1>
+            <h1>getblockhash - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockhash index
 

--- a/getblockhash.html
+++ b/getblockhash.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockhash">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockhash">
     <meta name="author" content="">
-    <title>getblockhash - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockhash - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhash - Zcash 6.12.1 RPC</h1>
+            <h1>getblockhash - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockhash index
 

--- a/getblockhashes.html
+++ b/getblockhashes.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockhashes">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockhashes">
     <meta name="author" content="">
-    <title>getblockhashes - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockhashes - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,35 +23,20 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhashes - Zcash 6.2.0 RPC</h1>
+            <h1>getblockhashes - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockhashes high low ( {&#34;noOrphans&#34;: true|false, &#34;logicalTimes&#34;: true|false} )
 
 Returns array of hashes of blocks within the timestamp range provided,
 
 greater or equal to low, less than high.
-
-WARNING: getblockhashes is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer or:
--experimentalfeatures and -lightwalletd
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
-
-or:
-
-experimentalfeatures=1
-lightwalletd=1
 
 Arguments:
 1. high                            (numeric, required) The newer block timestamp

--- a/getblockhashes.html
+++ b/getblockhashes.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockhashes">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockhashes">
     <meta name="author" content="">
-    <title>getblockhashes - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockhashes - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhashes - Zcash 6.12.1 RPC</h1>
+            <h1>getblockhashes - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockhashes high low ( {&#34;noOrphans&#34;: true|false, &#34;logicalTimes&#34;: true|false} )
 

--- a/getblockhashes.html
+++ b/getblockhashes.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockhashes">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockhashes">
     <meta name="author" content="">
-    <title>getblockhashes - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockhashes - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockhashes - Zcash 6.10.0 RPC</h1>
+            <h1>getblockhashes - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockhashes high low ( {&#34;noOrphans&#34;: true|false, &#34;logicalTimes&#34;: true|false} )
 

--- a/getblockheader.html
+++ b/getblockheader.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockheader">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblockheader">
     <meta name="author" content="">
-    <title>getblockheader - Zcash 6.12.1 RPC Docs</title>
+    <title>getblockheader - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockheader - Zcash 6.12.1 RPC</h1>
+            <h1>getblockheader - Zcash 6.12.2 RPC</h1>
           
             <pre>getblockheader &#34;hash&#34; ( verbose )
 

--- a/getblockheader.html
+++ b/getblockheader.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblockheader">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockheader">
     <meta name="author" content="">
-    <title>getblockheader - Zcash 6.2.0 RPC Docs</title>
+    <title>getblockheader - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockheader - Zcash 6.2.0 RPC</h1>
+            <h1>getblockheader - Zcash 6.10.0 RPC</h1>
           
             <pre>getblockheader &#34;hash&#34; ( verbose )
 

--- a/getblockheader.html
+++ b/getblockheader.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblockheader">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblockheader">
     <meta name="author" content="">
-    <title>getblockheader - Zcash 6.10.0 RPC Docs</title>
+    <title>getblockheader - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblockheader - Zcash 6.10.0 RPC</h1>
+            <h1>getblockheader - Zcash 6.12.1 RPC</h1>
           
             <pre>getblockheader &#34;hash&#34; ( verbose )
 

--- a/getblocksubsidy.html
+++ b/getblocksubsidy.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblocksubsidy">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblocksubsidy">
     <meta name="author" content="">
-    <title>getblocksubsidy - Zcash 6.12.1 RPC Docs</title>
+    <title>getblocksubsidy - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocksubsidy - Zcash 6.12.1 RPC</h1>
+            <h1>getblocksubsidy - Zcash 6.12.2 RPC</h1>
           
             <pre>getblocksubsidy height
 

--- a/getblocksubsidy.html
+++ b/getblocksubsidy.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblocksubsidy">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblocksubsidy">
     <meta name="author" content="">
-    <title>getblocksubsidy - Zcash 6.2.0 RPC Docs</title>
+    <title>getblocksubsidy - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocksubsidy - Zcash 6.2.0 RPC</h1>
+            <h1>getblocksubsidy - Zcash 6.10.0 RPC</h1>
           
             <pre>getblocksubsidy height
 

--- a/getblocksubsidy.html
+++ b/getblocksubsidy.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblocksubsidy">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblocksubsidy">
     <meta name="author" content="">
-    <title>getblocksubsidy - Zcash 6.10.0 RPC Docs</title>
+    <title>getblocksubsidy - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocksubsidy - Zcash 6.10.0 RPC</h1>
+            <h1>getblocksubsidy - Zcash 6.12.1 RPC</h1>
           
             <pre>getblocksubsidy height
 

--- a/getblocktemplate.html
+++ b/getblocktemplate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblocktemplate">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getblocktemplate">
     <meta name="author" content="">
-    <title>getblocktemplate - Zcash 6.12.1 RPC Docs</title>
+    <title>getblocktemplate - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocktemplate - Zcash 6.12.1 RPC</h1>
+            <h1>getblocktemplate - Zcash 6.12.2 RPC</h1>
           
             <pre>getblocktemplate ( &#34;jsonrequestobject&#34; )
 

--- a/getblocktemplate.html
+++ b/getblocktemplate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblocktemplate">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getblocktemplate">
     <meta name="author" content="">
-    <title>getblocktemplate - Zcash 6.10.0 RPC Docs</title>
+    <title>getblocktemplate - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocktemplate - Zcash 6.10.0 RPC</h1>
+            <h1>getblocktemplate - Zcash 6.12.1 RPC</h1>
           
             <pre>getblocktemplate ( &#34;jsonrequestobject&#34; )
 

--- a/getblocktemplate.html
+++ b/getblocktemplate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getblocktemplate">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getblocktemplate">
     <meta name="author" content="">
-    <title>getblocktemplate - Zcash 6.2.0 RPC Docs</title>
+    <title>getblocktemplate - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getblocktemplate - Zcash 6.2.0 RPC</h1>
+            <h1>getblocktemplate - Zcash 6.10.0 RPC</h1>
           
             <pre>getblocktemplate ( &#34;jsonrequestobject&#34; )
 

--- a/getchaintips.html
+++ b/getchaintips.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getchaintips">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getchaintips">
     <meta name="author" content="">
-    <title>getchaintips - Zcash 6.12.1 RPC Docs</title>
+    <title>getchaintips - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getchaintips - Zcash 6.12.1 RPC</h1>
+            <h1>getchaintips - Zcash 6.12.2 RPC</h1>
           
             <pre>getchaintips
 Return information about all known tips in the block tree, including the main chain as well as orphaned branches.

--- a/getchaintips.html
+++ b/getchaintips.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getchaintips">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getchaintips">
     <meta name="author" content="">
-    <title>getchaintips - Zcash 6.10.0 RPC Docs</title>
+    <title>getchaintips - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getchaintips - Zcash 6.10.0 RPC</h1>
+            <h1>getchaintips - Zcash 6.12.1 RPC</h1>
           
             <pre>getchaintips
 Return information about all known tips in the block tree, including the main chain as well as orphaned branches.

--- a/getchaintips.html
+++ b/getchaintips.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getchaintips">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getchaintips">
     <meta name="author" content="">
-    <title>getchaintips - Zcash 6.2.0 RPC Docs</title>
+    <title>getchaintips - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getchaintips - Zcash 6.2.0 RPC</h1>
+            <h1>getchaintips - Zcash 6.10.0 RPC</h1>
           
             <pre>getchaintips
 Return information about all known tips in the block tree, including the main chain as well as orphaned branches.

--- a/getconnectioncount.html
+++ b/getconnectioncount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getconnectioncount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getconnectioncount">
     <meta name="author" content="">
-    <title>getconnectioncount - Zcash 6.10.0 RPC Docs</title>
+    <title>getconnectioncount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getconnectioncount - Zcash 6.10.0 RPC</h1>
+            <h1>getconnectioncount - Zcash 6.12.1 RPC</h1>
           
             <pre>getconnectioncount
 

--- a/getconnectioncount.html
+++ b/getconnectioncount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getconnectioncount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getconnectioncount">
     <meta name="author" content="">
-    <title>getconnectioncount - Zcash 6.2.0 RPC Docs</title>
+    <title>getconnectioncount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getconnectioncount - Zcash 6.2.0 RPC</h1>
+            <h1>getconnectioncount - Zcash 6.10.0 RPC</h1>
           
             <pre>getconnectioncount
 

--- a/getconnectioncount.html
+++ b/getconnectioncount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getconnectioncount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getconnectioncount">
     <meta name="author" content="">
-    <title>getconnectioncount - Zcash 6.12.1 RPC Docs</title>
+    <title>getconnectioncount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getconnectioncount - Zcash 6.12.1 RPC</h1>
+            <h1>getconnectioncount - Zcash 6.12.2 RPC</h1>
           
             <pre>getconnectioncount
 

--- a/getdeprecationinfo.html
+++ b/getdeprecationinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getdeprecationinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getdeprecationinfo">
     <meta name="author" content="">
-    <title>getdeprecationinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getdeprecationinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdeprecationinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getdeprecationinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getdeprecationinfo
 Returns an object containing current version and deprecation block height. Applicable only on mainnet.

--- a/getdeprecationinfo.html
+++ b/getdeprecationinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getdeprecationinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getdeprecationinfo">
     <meta name="author" content="">
-    <title>getdeprecationinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getdeprecationinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdeprecationinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getdeprecationinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getdeprecationinfo
 Returns an object containing current version and deprecation block height. Applicable only on mainnet.

--- a/getdeprecationinfo.html
+++ b/getdeprecationinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getdeprecationinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getdeprecationinfo">
     <meta name="author" content="">
-    <title>getdeprecationinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getdeprecationinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdeprecationinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getdeprecationinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getdeprecationinfo
 Returns an object containing current version and deprecation block height. Applicable only on mainnet.

--- a/getdifficulty.html
+++ b/getdifficulty.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getdifficulty">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getdifficulty">
     <meta name="author" content="">
-    <title>getdifficulty - Zcash 6.2.0 RPC Docs</title>
+    <title>getdifficulty - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdifficulty - Zcash 6.2.0 RPC</h1>
+            <h1>getdifficulty - Zcash 6.10.0 RPC</h1>
           
             <pre>getdifficulty
 

--- a/getdifficulty.html
+++ b/getdifficulty.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getdifficulty">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getdifficulty">
     <meta name="author" content="">
-    <title>getdifficulty - Zcash 6.12.1 RPC Docs</title>
+    <title>getdifficulty - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdifficulty - Zcash 6.12.1 RPC</h1>
+            <h1>getdifficulty - Zcash 6.12.2 RPC</h1>
           
             <pre>getdifficulty
 

--- a/getdifficulty.html
+++ b/getdifficulty.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getdifficulty">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getdifficulty">
     <meta name="author" content="">
-    <title>getdifficulty - Zcash 6.10.0 RPC Docs</title>
+    <title>getdifficulty - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getdifficulty - Zcash 6.10.0 RPC</h1>
+            <h1>getdifficulty - Zcash 6.12.1 RPC</h1>
           
             <pre>getdifficulty
 

--- a/getexperimentalfeatures.html
+++ b/getexperimentalfeatures.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getexperimentalfeatures">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getexperimentalfeatures">
     <meta name="author" content="">
-    <title>getexperimentalfeatures - Zcash 6.2.0 RPC Docs</title>
+    <title>getexperimentalfeatures - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getexperimentalfeatures - Zcash 6.2.0 RPC</h1>
+            <h1>getexperimentalfeatures - Zcash 6.10.0 RPC</h1>
           
             <pre>getexperimentalfeatures
 

--- a/getexperimentalfeatures.html
+++ b/getexperimentalfeatures.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getexperimentalfeatures">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getexperimentalfeatures">
     <meta name="author" content="">
-    <title>getexperimentalfeatures - Zcash 6.12.1 RPC Docs</title>
+    <title>getexperimentalfeatures - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getexperimentalfeatures - Zcash 6.12.1 RPC</h1>
+            <h1>getexperimentalfeatures - Zcash 6.12.2 RPC</h1>
           
             <pre>getexperimentalfeatures
 

--- a/getexperimentalfeatures.html
+++ b/getexperimentalfeatures.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getexperimentalfeatures">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getexperimentalfeatures">
     <meta name="author" content="">
-    <title>getexperimentalfeatures - Zcash 6.10.0 RPC Docs</title>
+    <title>getexperimentalfeatures - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getexperimentalfeatures - Zcash 6.10.0 RPC</h1>
+            <h1>getexperimentalfeatures - Zcash 6.12.1 RPC</h1>
           
             <pre>getexperimentalfeatures
 

--- a/getgenerate.html
+++ b/getgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getgenerate">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getgenerate">
     <meta name="author" content="">
-    <title>getgenerate - Zcash 6.2.0 RPC Docs</title>
+    <title>getgenerate - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getgenerate - Zcash 6.2.0 RPC</h1>
+            <h1>getgenerate - Zcash 6.10.0 RPC</h1>
           
             <pre>getgenerate
 

--- a/getgenerate.html
+++ b/getgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getgenerate">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getgenerate">
     <meta name="author" content="">
-    <title>getgenerate - Zcash 6.10.0 RPC Docs</title>
+    <title>getgenerate - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getgenerate - Zcash 6.10.0 RPC</h1>
+            <h1>getgenerate - Zcash 6.12.1 RPC</h1>
           
             <pre>getgenerate
 

--- a/getgenerate.html
+++ b/getgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getgenerate">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getgenerate">
     <meta name="author" content="">
-    <title>getgenerate - Zcash 6.12.1 RPC Docs</title>
+    <title>getgenerate - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getgenerate - Zcash 6.12.1 RPC</h1>
+            <h1>getgenerate - Zcash 6.12.2 RPC</h1>
           
             <pre>getgenerate
 

--- a/getinfo.html
+++ b/getinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getinfo">
     <meta name="author" content="">
-    <title>getinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getinfo
 Returns an object containing various state info.

--- a/getinfo.html
+++ b/getinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getinfo">
     <meta name="author" content="">
-    <title>getinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getinfo
 Returns an object containing various state info.

--- a/getinfo.html
+++ b/getinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getinfo">
     <meta name="author" content="">
-    <title>getinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getinfo
 Returns an object containing various state info.

--- a/getlocalsolps.html
+++ b/getlocalsolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getlocalsolps">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getlocalsolps">
     <meta name="author" content="">
-    <title>getlocalsolps - Zcash 6.12.1 RPC Docs</title>
+    <title>getlocalsolps - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getlocalsolps - Zcash 6.12.1 RPC</h1>
+            <h1>getlocalsolps - Zcash 6.12.2 RPC</h1>
           
             <pre>getlocalsolps
 

--- a/getlocalsolps.html
+++ b/getlocalsolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getlocalsolps">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getlocalsolps">
     <meta name="author" content="">
-    <title>getlocalsolps - Zcash 6.2.0 RPC Docs</title>
+    <title>getlocalsolps - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getlocalsolps - Zcash 6.2.0 RPC</h1>
+            <h1>getlocalsolps - Zcash 6.10.0 RPC</h1>
           
             <pre>getlocalsolps
 

--- a/getlocalsolps.html
+++ b/getlocalsolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getlocalsolps">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getlocalsolps">
     <meta name="author" content="">
-    <title>getlocalsolps - Zcash 6.10.0 RPC Docs</title>
+    <title>getlocalsolps - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getlocalsolps - Zcash 6.10.0 RPC</h1>
+            <h1>getlocalsolps - Zcash 6.12.1 RPC</h1>
           
             <pre>getlocalsolps
 

--- a/getmemoryinfo.html
+++ b/getmemoryinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmemoryinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getmemoryinfo">
     <meta name="author" content="">
-    <title>getmemoryinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getmemoryinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmemoryinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getmemoryinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getmemoryinfo
 Returns an object containing information about memory usage.

--- a/getmemoryinfo.html
+++ b/getmemoryinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getmemoryinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmemoryinfo">
     <meta name="author" content="">
-    <title>getmemoryinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getmemoryinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmemoryinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getmemoryinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getmemoryinfo
 Returns an object containing information about memory usage.

--- a/getmemoryinfo.html
+++ b/getmemoryinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmemoryinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmemoryinfo">
     <meta name="author" content="">
-    <title>getmemoryinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getmemoryinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmemoryinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getmemoryinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getmemoryinfo
 Returns an object containing information about memory usage.

--- a/getmempoolinfo.html
+++ b/getmempoolinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmempoolinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmempoolinfo">
     <meta name="author" content="">
-    <title>getmempoolinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getmempoolinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmempoolinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getmempoolinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getmempoolinfo
 

--- a/getmempoolinfo.html
+++ b/getmempoolinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmempoolinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getmempoolinfo">
     <meta name="author" content="">
-    <title>getmempoolinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getmempoolinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmempoolinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getmempoolinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getmempoolinfo
 

--- a/getmempoolinfo.html
+++ b/getmempoolinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getmempoolinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmempoolinfo">
     <meta name="author" content="">
-    <title>getmempoolinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getmempoolinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmempoolinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getmempoolinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getmempoolinfo
 

--- a/getmininginfo.html
+++ b/getmininginfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmininginfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getmininginfo">
     <meta name="author" content="">
-    <title>getmininginfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getmininginfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmininginfo - Zcash 6.12.1 RPC</h1>
+            <h1>getmininginfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getmininginfo
 

--- a/getmininginfo.html
+++ b/getmininginfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getmininginfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmininginfo">
     <meta name="author" content="">
-    <title>getmininginfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getmininginfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmininginfo - Zcash 6.2.0 RPC</h1>
+            <h1>getmininginfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getmininginfo
 

--- a/getmininginfo.html
+++ b/getmininginfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getmininginfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getmininginfo">
     <meta name="author" content="">
-    <title>getmininginfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getmininginfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getmininginfo - Zcash 6.10.0 RPC</h1>
+            <h1>getmininginfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getmininginfo
 

--- a/getnettotals.html
+++ b/getnettotals.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getnettotals">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnettotals">
     <meta name="author" content="">
-    <title>getnettotals - Zcash 6.2.0 RPC Docs</title>
+    <title>getnettotals - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnettotals - Zcash 6.2.0 RPC</h1>
+            <h1>getnettotals - Zcash 6.10.0 RPC</h1>
           
             <pre>getnettotals
 

--- a/getnettotals.html
+++ b/getnettotals.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnettotals">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnettotals">
     <meta name="author" content="">
-    <title>getnettotals - Zcash 6.10.0 RPC Docs</title>
+    <title>getnettotals - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnettotals - Zcash 6.10.0 RPC</h1>
+            <h1>getnettotals - Zcash 6.12.1 RPC</h1>
           
             <pre>getnettotals
 

--- a/getnettotals.html
+++ b/getnettotals.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnettotals">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getnettotals">
     <meta name="author" content="">
-    <title>getnettotals - Zcash 6.12.1 RPC Docs</title>
+    <title>getnettotals - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnettotals - Zcash 6.12.1 RPC</h1>
+            <h1>getnettotals - Zcash 6.12.2 RPC</h1>
           
             <pre>getnettotals
 

--- a/getnetworkhashps.html
+++ b/getnetworkhashps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getnetworkhashps">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworkhashps">
     <meta name="author" content="">
-    <title>getnetworkhashps - Zcash 6.2.0 RPC Docs</title>
+    <title>getnetworkhashps - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkhashps - Zcash 6.2.0 RPC</h1>
+            <h1>getnetworkhashps - Zcash 6.10.0 RPC</h1>
           
             <pre>getnetworkhashps ( blocks height )
 

--- a/getnetworkhashps.html
+++ b/getnetworkhashps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworkhashps">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworkhashps">
     <meta name="author" content="">
-    <title>getnetworkhashps - Zcash 6.10.0 RPC Docs</title>
+    <title>getnetworkhashps - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkhashps - Zcash 6.10.0 RPC</h1>
+            <h1>getnetworkhashps - Zcash 6.12.1 RPC</h1>
           
             <pre>getnetworkhashps ( blocks height )
 

--- a/getnetworkhashps.html
+++ b/getnetworkhashps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworkhashps">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getnetworkhashps">
     <meta name="author" content="">
-    <title>getnetworkhashps - Zcash 6.12.1 RPC Docs</title>
+    <title>getnetworkhashps - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkhashps - Zcash 6.12.1 RPC</h1>
+            <h1>getnetworkhashps - Zcash 6.12.2 RPC</h1>
           
             <pre>getnetworkhashps ( blocks height )
 

--- a/getnetworkinfo.html
+++ b/getnetworkinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworkinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getnetworkinfo">
     <meta name="author" content="">
-    <title>getnetworkinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getnetworkinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getnetworkinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getnetworkinfo
 Returns an object containing various state info regarding P2P networking.

--- a/getnetworkinfo.html
+++ b/getnetworkinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getnetworkinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworkinfo">
     <meta name="author" content="">
-    <title>getnetworkinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getnetworkinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getnetworkinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getnetworkinfo
 Returns an object containing various state info regarding P2P networking.

--- a/getnetworkinfo.html
+++ b/getnetworkinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworkinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworkinfo">
     <meta name="author" content="">
-    <title>getnetworkinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getnetworkinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworkinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getnetworkinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getnetworkinfo
 Returns an object containing various state info regarding P2P networking.

--- a/getnetworksolps.html
+++ b/getnetworksolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworksolps">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworksolps">
     <meta name="author" content="">
-    <title>getnetworksolps - Zcash 6.10.0 RPC Docs</title>
+    <title>getnetworksolps - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworksolps - Zcash 6.10.0 RPC</h1>
+            <h1>getnetworksolps - Zcash 6.12.1 RPC</h1>
           
             <pre>getnetworksolps ( blocks height )
 

--- a/getnetworksolps.html
+++ b/getnetworksolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnetworksolps">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getnetworksolps">
     <meta name="author" content="">
-    <title>getnetworksolps - Zcash 6.12.1 RPC Docs</title>
+    <title>getnetworksolps - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworksolps - Zcash 6.12.1 RPC</h1>
+            <h1>getnetworksolps - Zcash 6.12.2 RPC</h1>
           
             <pre>getnetworksolps ( blocks height )
 

--- a/getnetworksolps.html
+++ b/getnetworksolps.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getnetworksolps">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnetworksolps">
     <meta name="author" content="">
-    <title>getnetworksolps - Zcash 6.2.0 RPC Docs</title>
+    <title>getnetworksolps - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnetworksolps - Zcash 6.2.0 RPC</h1>
+            <h1>getnetworksolps - Zcash 6.10.0 RPC</h1>
           
             <pre>getnetworksolps ( blocks height )
 

--- a/getnewaddress.html
+++ b/getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnewaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnewaddress">
     <meta name="author" content="">
-    <title>getnewaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>getnewaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnewaddress - Zcash 6.10.0 RPC</h1>
+            <h1>getnewaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>getnewaddress ( &#34;&#34; )
 

--- a/getnewaddress.html
+++ b/getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getnewaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getnewaddress">
     <meta name="author" content="">
-    <title>getnewaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>getnewaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnewaddress - Zcash 6.12.1 RPC</h1>
+            <h1>getnewaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>getnewaddress ( &#34;&#34; )
 

--- a/getnewaddress.html
+++ b/getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getnewaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getnewaddress">
     <meta name="author" content="">
-    <title>getnewaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>getnewaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getnewaddress - Zcash 6.2.0 RPC</h1>
+            <h1>getnewaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>getnewaddress ( &#34;&#34; )
 

--- a/getpeerinfo.html
+++ b/getpeerinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getpeerinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getpeerinfo">
     <meta name="author" content="">
-    <title>getpeerinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getpeerinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getpeerinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getpeerinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getpeerinfo
 

--- a/getpeerinfo.html
+++ b/getpeerinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getpeerinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getpeerinfo">
     <meta name="author" content="">
-    <title>getpeerinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getpeerinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getpeerinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getpeerinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getpeerinfo
 

--- a/getpeerinfo.html
+++ b/getpeerinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getpeerinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getpeerinfo">
     <meta name="author" content="">
-    <title>getpeerinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getpeerinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getpeerinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getpeerinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getpeerinfo
 

--- a/getrawchangeaddress.html
+++ b/getrawchangeaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getrawchangeaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawchangeaddress">
     <meta name="author" content="">
-    <title>getrawchangeaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>getrawchangeaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawchangeaddress - Zcash 6.2.0 RPC</h1>
+            <h1>getrawchangeaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>getrawchangeaddress
 

--- a/getrawchangeaddress.html
+++ b/getrawchangeaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawchangeaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawchangeaddress">
     <meta name="author" content="">
-    <title>getrawchangeaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>getrawchangeaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawchangeaddress - Zcash 6.10.0 RPC</h1>
+            <h1>getrawchangeaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>getrawchangeaddress
 

--- a/getrawchangeaddress.html
+++ b/getrawchangeaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawchangeaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getrawchangeaddress">
     <meta name="author" content="">
-    <title>getrawchangeaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>getrawchangeaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawchangeaddress - Zcash 6.12.1 RPC</h1>
+            <h1>getrawchangeaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>getrawchangeaddress
 

--- a/getrawmempool.html
+++ b/getrawmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawmempool">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getrawmempool">
     <meta name="author" content="">
-    <title>getrawmempool - Zcash 6.12.1 RPC Docs</title>
+    <title>getrawmempool - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawmempool - Zcash 6.12.1 RPC</h1>
+            <h1>getrawmempool - Zcash 6.12.2 RPC</h1>
           
             <pre>getrawmempool ( verbose )
 

--- a/getrawmempool.html
+++ b/getrawmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getrawmempool">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawmempool">
     <meta name="author" content="">
-    <title>getrawmempool - Zcash 6.2.0 RPC Docs</title>
+    <title>getrawmempool - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawmempool - Zcash 6.2.0 RPC</h1>
+            <h1>getrawmempool - Zcash 6.10.0 RPC</h1>
           
             <pre>getrawmempool ( verbose )
 

--- a/getrawmempool.html
+++ b/getrawmempool.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawmempool">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawmempool">
     <meta name="author" content="">
-    <title>getrawmempool - Zcash 6.10.0 RPC Docs</title>
+    <title>getrawmempool - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawmempool - Zcash 6.10.0 RPC</h1>
+            <h1>getrawmempool - Zcash 6.12.1 RPC</h1>
           
             <pre>getrawmempool ( verbose )
 

--- a/getrawtransaction.html
+++ b/getrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getrawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawtransaction">
     <meta name="author" content="">
-    <title>getrawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>getrawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>getrawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>getrawtransaction &#34;txid&#34; ( verbose &#34;blockhash&#34; )
 

--- a/getrawtransaction.html
+++ b/getrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getrawtransaction">
     <meta name="author" content="">
-    <title>getrawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>getrawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>getrawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>getrawtransaction &#34;txid&#34; ( verbose &#34;blockhash&#34; )
 

--- a/getrawtransaction.html
+++ b/getrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getrawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getrawtransaction">
     <meta name="author" content="">
-    <title>getrawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>getrawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getrawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>getrawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>getrawtransaction &#34;txid&#34; ( verbose &#34;blockhash&#34; )
 

--- a/getreceivedbyaddress.html
+++ b/getreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getreceivedbyaddress">
     <meta name="author" content="">
-    <title>getreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>getreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getreceivedbyaddress - Zcash 6.10.0 RPC</h1>
+            <h1>getreceivedbyaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>getreceivedbyaddress &#34;zcashaddress&#34; ( minconf inZat asOfHeight )
 

--- a/getreceivedbyaddress.html
+++ b/getreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getreceivedbyaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getreceivedbyaddress">
     <meta name="author" content="">
-    <title>getreceivedbyaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>getreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getreceivedbyaddress - Zcash 6.2.0 RPC</h1>
+            <h1>getreceivedbyaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>getreceivedbyaddress &#34;zcashaddress&#34; ( minconf inZat asOfHeight )
 

--- a/getreceivedbyaddress.html
+++ b/getreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getreceivedbyaddress">
     <meta name="author" content="">
-    <title>getreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>getreceivedbyaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getreceivedbyaddress - Zcash 6.12.1 RPC</h1>
+            <h1>getreceivedbyaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>getreceivedbyaddress &#34;zcashaddress&#34; ( minconf inZat asOfHeight )
 

--- a/getspentinfo.html
+++ b/getspentinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getspentinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getspentinfo">
     <meta name="author" content="">
-    <title>getspentinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getspentinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getspentinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getspentinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getspentinfo {&#34;txid&#34;: &#34;txidhex&#34;, &#34;index&#34;: n}
 

--- a/getspentinfo.html
+++ b/getspentinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getspentinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getspentinfo">
     <meta name="author" content="">
-    <title>getspentinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getspentinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,27 +23,18 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getspentinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getspentinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getspentinfo {&#34;txid&#34;: &#34;txidhex&#34;, &#34;index&#34;: n}
 
 Returns the txid and index where an output is spent.
-
-WARNING: getspentinfo is disabled.
-To enable it, restart zcashd with the following command line options:
--experimentalfeatures and -insightexplorer
-
-Alternatively add these two lines to the zcash.conf file:
-
-experimentalfeatures=1
-insightexplorer=1
 
 Arguments:
 {

--- a/getspentinfo.html
+++ b/getspentinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getspentinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getspentinfo">
     <meta name="author" content="">
-    <title>getspentinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getspentinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getspentinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getspentinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getspentinfo {&#34;txid&#34;: &#34;txidhex&#34;, &#34;index&#34;: n}
 

--- a/gettransaction.html
+++ b/gettransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - gettransaction">
     <meta name="author" content="">
-    <title>gettransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>gettransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettransaction - Zcash 6.12.1 RPC</h1>
+            <h1>gettransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>gettransaction &#34;txid&#34; ( includeWatchonly verbose asOfHeight )
 

--- a/gettransaction.html
+++ b/gettransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettransaction">
     <meta name="author" content="">
-    <title>gettransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>gettransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettransaction - Zcash 6.10.0 RPC</h1>
+            <h1>gettransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>gettransaction &#34;txid&#34; ( includeWatchonly verbose asOfHeight )
 

--- a/gettransaction.html
+++ b/gettransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - gettransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettransaction">
     <meta name="author" content="">
-    <title>gettransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>gettransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettransaction - Zcash 6.2.0 RPC</h1>
+            <h1>gettransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>gettransaction &#34;txid&#34; ( includeWatchonly verbose asOfHeight )
 

--- a/gettxout.html
+++ b/gettxout.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - gettxout">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxout">
     <meta name="author" content="">
-    <title>gettxout - Zcash 6.2.0 RPC Docs</title>
+    <title>gettxout - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxout - Zcash 6.2.0 RPC</h1>
+            <h1>gettxout - Zcash 6.10.0 RPC</h1>
           
             <pre>gettxout &#34;txid&#34; n ( includemempool )
 

--- a/gettxout.html
+++ b/gettxout.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxout">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxout">
     <meta name="author" content="">
-    <title>gettxout - Zcash 6.10.0 RPC Docs</title>
+    <title>gettxout - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxout - Zcash 6.10.0 RPC</h1>
+            <h1>gettxout - Zcash 6.12.1 RPC</h1>
           
             <pre>gettxout &#34;txid&#34; n ( includemempool )
 

--- a/gettxout.html
+++ b/gettxout.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxout">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - gettxout">
     <meta name="author" content="">
-    <title>gettxout - Zcash 6.12.1 RPC Docs</title>
+    <title>gettxout - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxout - Zcash 6.12.1 RPC</h1>
+            <h1>gettxout - Zcash 6.12.2 RPC</h1>
           
             <pre>gettxout &#34;txid&#34; n ( includemempool )
 

--- a/gettxoutproof.html
+++ b/gettxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxoutproof">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - gettxoutproof">
     <meta name="author" content="">
-    <title>gettxoutproof - Zcash 6.12.1 RPC Docs</title>
+    <title>gettxoutproof - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutproof - Zcash 6.12.1 RPC</h1>
+            <h1>gettxoutproof - Zcash 6.12.2 RPC</h1>
           
             <pre>gettxoutproof [&#34;txid&#34;,...] ( blockhash )
 

--- a/gettxoutproof.html
+++ b/gettxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxoutproof">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxoutproof">
     <meta name="author" content="">
-    <title>gettxoutproof - Zcash 6.10.0 RPC Docs</title>
+    <title>gettxoutproof - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutproof - Zcash 6.10.0 RPC</h1>
+            <h1>gettxoutproof - Zcash 6.12.1 RPC</h1>
           
             <pre>gettxoutproof [&#34;txid&#34;,...] ( blockhash )
 

--- a/gettxoutproof.html
+++ b/gettxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - gettxoutproof">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxoutproof">
     <meta name="author" content="">
-    <title>gettxoutproof - Zcash 6.2.0 RPC Docs</title>
+    <title>gettxoutproof - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutproof - Zcash 6.2.0 RPC</h1>
+            <h1>gettxoutproof - Zcash 6.10.0 RPC</h1>
           
             <pre>gettxoutproof [&#34;txid&#34;,...] ( blockhash )
 

--- a/gettxoutsetinfo.html
+++ b/gettxoutsetinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxoutsetinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - gettxoutsetinfo">
     <meta name="author" content="">
-    <title>gettxoutsetinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>gettxoutsetinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutsetinfo - Zcash 6.12.1 RPC</h1>
+            <h1>gettxoutsetinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>gettxoutsetinfo
 

--- a/gettxoutsetinfo.html
+++ b/gettxoutsetinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - gettxoutsetinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxoutsetinfo">
     <meta name="author" content="">
-    <title>gettxoutsetinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>gettxoutsetinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutsetinfo - Zcash 6.2.0 RPC</h1>
+            <h1>gettxoutsetinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>gettxoutsetinfo
 

--- a/gettxoutsetinfo.html
+++ b/gettxoutsetinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - gettxoutsetinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - gettxoutsetinfo">
     <meta name="author" content="">
-    <title>gettxoutsetinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>gettxoutsetinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>gettxoutsetinfo - Zcash 6.10.0 RPC</h1>
+            <h1>gettxoutsetinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>gettxoutsetinfo
 

--- a/getunconfirmedbalance.html
+++ b/getunconfirmedbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getunconfirmedbalance">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getunconfirmedbalance">
     <meta name="author" content="">
-    <title>getunconfirmedbalance - Zcash 6.10.0 RPC Docs</title>
+    <title>getunconfirmedbalance - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getunconfirmedbalance - Zcash 6.10.0 RPC</h1>
+            <h1>getunconfirmedbalance - Zcash 6.12.1 RPC</h1>
           
             <pre>getunconfirmedbalance
 Returns the server&#39;s total unconfirmed transparent balance

--- a/getunconfirmedbalance.html
+++ b/getunconfirmedbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getunconfirmedbalance">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getunconfirmedbalance">
     <meta name="author" content="">
-    <title>getunconfirmedbalance - Zcash 6.12.1 RPC Docs</title>
+    <title>getunconfirmedbalance - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getunconfirmedbalance - Zcash 6.12.1 RPC</h1>
+            <h1>getunconfirmedbalance - Zcash 6.12.2 RPC</h1>
           
             <pre>getunconfirmedbalance
 Returns the server&#39;s total unconfirmed transparent balance

--- a/getunconfirmedbalance.html
+++ b/getunconfirmedbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getunconfirmedbalance">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getunconfirmedbalance">
     <meta name="author" content="">
-    <title>getunconfirmedbalance - Zcash 6.2.0 RPC Docs</title>
+    <title>getunconfirmedbalance - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getunconfirmedbalance - Zcash 6.2.0 RPC</h1>
+            <h1>getunconfirmedbalance - Zcash 6.10.0 RPC</h1>
           
             <pre>getunconfirmedbalance
 Returns the server&#39;s total unconfirmed transparent balance

--- a/getwalletinfo.html
+++ b/getwalletinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - getwalletinfo">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - getwalletinfo">
     <meta name="author" content="">
-    <title>getwalletinfo - Zcash 6.10.0 RPC Docs</title>
+    <title>getwalletinfo - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getwalletinfo - Zcash 6.10.0 RPC</h1>
+            <h1>getwalletinfo - Zcash 6.12.1 RPC</h1>
           
             <pre>getwalletinfo ( asOfHeight )
 Returns wallet state information.

--- a/getwalletinfo.html
+++ b/getwalletinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - getwalletinfo">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - getwalletinfo">
     <meta name="author" content="">
-    <title>getwalletinfo - Zcash 6.2.0 RPC Docs</title>
+    <title>getwalletinfo - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getwalletinfo - Zcash 6.2.0 RPC</h1>
+            <h1>getwalletinfo - Zcash 6.10.0 RPC</h1>
           
             <pre>getwalletinfo ( asOfHeight )
 Returns wallet state information.

--- a/getwalletinfo.html
+++ b/getwalletinfo.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - getwalletinfo">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - getwalletinfo">
     <meta name="author" content="">
-    <title>getwalletinfo - Zcash 6.12.1 RPC Docs</title>
+    <title>getwalletinfo - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>getwalletinfo - Zcash 6.12.1 RPC</h1>
+            <h1>getwalletinfo - Zcash 6.12.2 RPC</h1>
           
             <pre>getwalletinfo ( asOfHeight )
 Returns wallet state information.

--- a/help.html
+++ b/help.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - help">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - help">
     <meta name="author" content="">
-    <title>help - Zcash 6.2.0 RPC Docs</title>
+    <title>help - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>help - Zcash 6.2.0 RPC</h1>
+            <h1>help - Zcash 6.10.0 RPC</h1>
           
             <pre>help ( &#34;command&#34; )
 

--- a/help.html
+++ b/help.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - help">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - help">
     <meta name="author" content="">
-    <title>help - Zcash 6.12.1 RPC Docs</title>
+    <title>help - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>help - Zcash 6.12.1 RPC</h1>
+            <h1>help - Zcash 6.12.2 RPC</h1>
           
             <pre>help ( &#34;command&#34; )
 

--- a/help.html
+++ b/help.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - help">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - help">
     <meta name="author" content="">
-    <title>help - Zcash 6.10.0 RPC Docs</title>
+    <title>help - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>help - Zcash 6.10.0 RPC</h1>
+            <h1>help - Zcash 6.12.1 RPC</h1>
           
             <pre>help ( &#34;command&#34; )
 

--- a/importaddress.html
+++ b/importaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - importaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - importaddress">
     <meta name="author" content="">
-    <title>importaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>importaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importaddress - Zcash 6.10.0 RPC</h1>
+            <h1>importaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>importaddress &#34;address&#34; ( &#34;label&#34; rescan p2sh )
 

--- a/importaddress.html
+++ b/importaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - importaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - importaddress">
     <meta name="author" content="">
-    <title>importaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>importaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importaddress - Zcash 6.2.0 RPC</h1>
+            <h1>importaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>importaddress &#34;address&#34; ( &#34;label&#34; rescan p2sh )
 

--- a/importaddress.html
+++ b/importaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - importaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - importaddress">
     <meta name="author" content="">
-    <title>importaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>importaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importaddress - Zcash 6.12.1 RPC</h1>
+            <h1>importaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>importaddress &#34;address&#34; ( &#34;label&#34; rescan p2sh )
 

--- a/importprivkey.html
+++ b/importprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - importprivkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - importprivkey">
     <meta name="author" content="">
-    <title>importprivkey - Zcash 6.10.0 RPC Docs</title>
+    <title>importprivkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importprivkey - Zcash 6.10.0 RPC</h1>
+            <h1>importprivkey - Zcash 6.12.1 RPC</h1>
           
             <pre>importprivkey &#34;zcashprivkey&#34; ( &#34;label&#34; rescan )
 

--- a/importprivkey.html
+++ b/importprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - importprivkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - importprivkey">
     <meta name="author" content="">
-    <title>importprivkey - Zcash 6.12.1 RPC Docs</title>
+    <title>importprivkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importprivkey - Zcash 6.12.1 RPC</h1>
+            <h1>importprivkey - Zcash 6.12.2 RPC</h1>
           
             <pre>importprivkey &#34;zcashprivkey&#34; ( &#34;label&#34; rescan )
 

--- a/importprivkey.html
+++ b/importprivkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - importprivkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - importprivkey">
     <meta name="author" content="">
-    <title>importprivkey - Zcash 6.2.0 RPC Docs</title>
+    <title>importprivkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importprivkey - Zcash 6.2.0 RPC</h1>
+            <h1>importprivkey - Zcash 6.10.0 RPC</h1>
           
             <pre>importprivkey &#34;zcashprivkey&#34; ( &#34;label&#34; rescan )
 

--- a/importpubkey.html
+++ b/importpubkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - importpubkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - importpubkey">
     <meta name="author" content="">
-    <title>importpubkey - Zcash 6.10.0 RPC Docs</title>
+    <title>importpubkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importpubkey - Zcash 6.10.0 RPC</h1>
+            <h1>importpubkey - Zcash 6.12.1 RPC</h1>
           
             <pre>importpubkey &#34;pubkey&#34; ( &#34;label&#34; rescan )
 

--- a/importpubkey.html
+++ b/importpubkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - importpubkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - importpubkey">
     <meta name="author" content="">
-    <title>importpubkey - Zcash 6.2.0 RPC Docs</title>
+    <title>importpubkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importpubkey - Zcash 6.2.0 RPC</h1>
+            <h1>importpubkey - Zcash 6.10.0 RPC</h1>
           
             <pre>importpubkey &#34;pubkey&#34; ( &#34;label&#34; rescan )
 

--- a/importpubkey.html
+++ b/importpubkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - importpubkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - importpubkey">
     <meta name="author" content="">
-    <title>importpubkey - Zcash 6.12.1 RPC Docs</title>
+    <title>importpubkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importpubkey - Zcash 6.12.1 RPC</h1>
+            <h1>importpubkey - Zcash 6.12.2 RPC</h1>
           
             <pre>importpubkey &#34;pubkey&#34; ( &#34;label&#34; rescan )
 

--- a/importwallet.html
+++ b/importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - importwallet">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - importwallet">
     <meta name="author" content="">
-    <title>importwallet - Zcash 6.12.1 RPC Docs</title>
+    <title>importwallet - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importwallet - Zcash 6.12.1 RPC</h1>
+            <h1>importwallet - Zcash 6.12.2 RPC</h1>
           
             <pre>importwallet &#34;filename&#34;
 

--- a/importwallet.html
+++ b/importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - importwallet">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - importwallet">
     <meta name="author" content="">
-    <title>importwallet - Zcash 6.10.0 RPC Docs</title>
+    <title>importwallet - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importwallet - Zcash 6.10.0 RPC</h1>
+            <h1>importwallet - Zcash 6.12.1 RPC</h1>
           
             <pre>importwallet &#34;filename&#34;
 

--- a/importwallet.html
+++ b/importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - importwallet">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - importwallet">
     <meta name="author" content="">
-    <title>importwallet - Zcash 6.2.0 RPC Docs</title>
+    <title>importwallet - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>importwallet - Zcash 6.2.0 RPC</h1>
+            <h1>importwallet - Zcash 6.10.0 RPC</h1>
           
             <pre>importwallet &#34;filename&#34;
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs">
     <meta name="author" content="">
-    <title>Zcash 6.12.1 RPC Docs</title>
+    <title>Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>Zcash 6.12.1 RPC</h1>
+            <h1>Zcash 6.12.2 RPC</h1>
           
           <p>
           License of the docs is MIT (see <a href="https://github.com/zcash/zcash">zcash repo</a>), license of the scripts and webpage is also MIT (<a href="https://github.com/zcash/rpc">github repo</a>)

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs">
     <meta name="author" content="">
-    <title>Zcash 6.2.0 RPC Docs</title>
+    <title>Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>Zcash 6.2.0 RPC</h1>
+            <h1>Zcash 6.10.0 RPC</h1>
           
           <p>
           License of the docs is MIT (see <a href="https://github.com/zcash/zcash">zcash repo</a>), license of the scripts and webpage is also MIT (<a href="https://github.com/zcash/rpc">github repo</a>)

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs">
     <meta name="author" content="">
-    <title>Zcash 6.10.0 RPC Docs</title>
+    <title>Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>Zcash 6.10.0 RPC</h1>
+            <h1>Zcash 6.12.1 RPC</h1>
           
           <p>
           License of the docs is MIT (see <a href="https://github.com/zcash/zcash">zcash repo</a>), license of the scripts and webpage is also MIT (<a href="https://github.com/zcash/rpc">github repo</a>)

--- a/keypoolrefill.html
+++ b/keypoolrefill.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - keypoolrefill">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - keypoolrefill">
     <meta name="author" content="">
-    <title>keypoolrefill - Zcash 6.12.1 RPC Docs</title>
+    <title>keypoolrefill - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>keypoolrefill - Zcash 6.12.1 RPC</h1>
+            <h1>keypoolrefill - Zcash 6.12.2 RPC</h1>
           
             <pre>keypoolrefill ( newsize )
 

--- a/keypoolrefill.html
+++ b/keypoolrefill.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - keypoolrefill">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - keypoolrefill">
     <meta name="author" content="">
-    <title>keypoolrefill - Zcash 6.10.0 RPC Docs</title>
+    <title>keypoolrefill - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>keypoolrefill - Zcash 6.10.0 RPC</h1>
+            <h1>keypoolrefill - Zcash 6.12.1 RPC</h1>
           
             <pre>keypoolrefill ( newsize )
 

--- a/keypoolrefill.html
+++ b/keypoolrefill.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - keypoolrefill">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - keypoolrefill">
     <meta name="author" content="">
-    <title>keypoolrefill - Zcash 6.2.0 RPC Docs</title>
+    <title>keypoolrefill - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>keypoolrefill - Zcash 6.2.0 RPC</h1>
+            <h1>keypoolrefill - Zcash 6.10.0 RPC</h1>
           
             <pre>keypoolrefill ( newsize )
 

--- a/listaddresses.html
+++ b/listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listaddresses">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listaddresses">
     <meta name="author" content="">
-    <title>listaddresses - Zcash 6.12.1 RPC Docs</title>
+    <title>listaddresses - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddresses - Zcash 6.12.1 RPC</h1>
+            <h1>listaddresses - Zcash 6.12.2 RPC</h1>
           
             <pre>listaddresses
 

--- a/listaddresses.html
+++ b/listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listaddresses">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listaddresses">
     <meta name="author" content="">
-    <title>listaddresses - Zcash 6.2.0 RPC Docs</title>
+    <title>listaddresses - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddresses - Zcash 6.2.0 RPC</h1>
+            <h1>listaddresses - Zcash 6.10.0 RPC</h1>
           
             <pre>listaddresses
 

--- a/listaddresses.html
+++ b/listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listaddresses">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listaddresses">
     <meta name="author" content="">
-    <title>listaddresses - Zcash 6.10.0 RPC Docs</title>
+    <title>listaddresses - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddresses - Zcash 6.10.0 RPC</h1>
+            <h1>listaddresses - Zcash 6.12.1 RPC</h1>
           
             <pre>listaddresses
 

--- a/listaddressgroupings.html
+++ b/listaddressgroupings.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listaddressgroupings">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listaddressgroupings">
     <meta name="author" content="">
-    <title>listaddressgroupings - Zcash 6.2.0 RPC Docs</title>
+    <title>listaddressgroupings - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddressgroupings - Zcash 6.2.0 RPC</h1>
+            <h1>listaddressgroupings - Zcash 6.10.0 RPC</h1>
           
             <pre>listaddressgroupings ( asOfHeight )
 

--- a/listaddressgroupings.html
+++ b/listaddressgroupings.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listaddressgroupings">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listaddressgroupings">
     <meta name="author" content="">
-    <title>listaddressgroupings - Zcash 6.10.0 RPC Docs</title>
+    <title>listaddressgroupings - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddressgroupings - Zcash 6.10.0 RPC</h1>
+            <h1>listaddressgroupings - Zcash 6.12.1 RPC</h1>
           
             <pre>listaddressgroupings ( asOfHeight )
 

--- a/listaddressgroupings.html
+++ b/listaddressgroupings.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listaddressgroupings">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listaddressgroupings">
     <meta name="author" content="">
-    <title>listaddressgroupings - Zcash 6.12.1 RPC Docs</title>
+    <title>listaddressgroupings - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listaddressgroupings - Zcash 6.12.1 RPC</h1>
+            <h1>listaddressgroupings - Zcash 6.12.2 RPC</h1>
           
             <pre>listaddressgroupings ( asOfHeight )
 

--- a/listbanned.html
+++ b/listbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listbanned">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listbanned">
     <meta name="author" content="">
-    <title>listbanned - Zcash 6.10.0 RPC Docs</title>
+    <title>listbanned - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listbanned - Zcash 6.10.0 RPC</h1>
+            <h1>listbanned - Zcash 6.12.1 RPC</h1>
           
             <pre>listbanned
 

--- a/listbanned.html
+++ b/listbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listbanned">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listbanned">
     <meta name="author" content="">
-    <title>listbanned - Zcash 6.2.0 RPC Docs</title>
+    <title>listbanned - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listbanned - Zcash 6.2.0 RPC</h1>
+            <h1>listbanned - Zcash 6.10.0 RPC</h1>
           
             <pre>listbanned
 

--- a/listbanned.html
+++ b/listbanned.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listbanned">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listbanned">
     <meta name="author" content="">
-    <title>listbanned - Zcash 6.12.1 RPC Docs</title>
+    <title>listbanned - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listbanned - Zcash 6.12.1 RPC</h1>
+            <h1>listbanned - Zcash 6.12.2 RPC</h1>
           
             <pre>listbanned
 

--- a/listlockunspent.html
+++ b/listlockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listlockunspent">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listlockunspent">
     <meta name="author" content="">
-    <title>listlockunspent - Zcash 6.10.0 RPC Docs</title>
+    <title>listlockunspent - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listlockunspent - Zcash 6.10.0 RPC</h1>
+            <h1>listlockunspent - Zcash 6.12.1 RPC</h1>
           
             <pre>listlockunspent
 

--- a/listlockunspent.html
+++ b/listlockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listlockunspent">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listlockunspent">
     <meta name="author" content="">
-    <title>listlockunspent - Zcash 6.2.0 RPC Docs</title>
+    <title>listlockunspent - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listlockunspent - Zcash 6.2.0 RPC</h1>
+            <h1>listlockunspent - Zcash 6.10.0 RPC</h1>
           
             <pre>listlockunspent
 

--- a/listlockunspent.html
+++ b/listlockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listlockunspent">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listlockunspent">
     <meta name="author" content="">
-    <title>listlockunspent - Zcash 6.12.1 RPC Docs</title>
+    <title>listlockunspent - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listlockunspent - Zcash 6.12.1 RPC</h1>
+            <h1>listlockunspent - Zcash 6.12.2 RPC</h1>
           
             <pre>listlockunspent
 

--- a/listreceivedbyaddress.html
+++ b/listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listreceivedbyaddress">
     <meta name="author" content="">
-    <title>listreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>listreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listreceivedbyaddress - Zcash 6.10.0 RPC</h1>
+            <h1>listreceivedbyaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>listreceivedbyaddress ( minconf includeempty includeWatchonly addressFilter includeImmatureCoinbase asOfHeight )
 

--- a/listreceivedbyaddress.html
+++ b/listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listreceivedbyaddress">
     <meta name="author" content="">
-    <title>listreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>listreceivedbyaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listreceivedbyaddress - Zcash 6.12.1 RPC</h1>
+            <h1>listreceivedbyaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>listreceivedbyaddress ( minconf includeempty includeWatchonly addressFilter includeImmatureCoinbase asOfHeight )
 

--- a/listreceivedbyaddress.html
+++ b/listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listreceivedbyaddress">
     <meta name="author" content="">
-    <title>listreceivedbyaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>listreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listreceivedbyaddress - Zcash 6.2.0 RPC</h1>
+            <h1>listreceivedbyaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>listreceivedbyaddress ( minconf includeempty includeWatchonly addressFilter includeImmatureCoinbase asOfHeight )
 

--- a/listsinceblock.html
+++ b/listsinceblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listsinceblock">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listsinceblock">
     <meta name="author" content="">
-    <title>listsinceblock - Zcash 6.10.0 RPC Docs</title>
+    <title>listsinceblock - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listsinceblock - Zcash 6.10.0 RPC</h1>
+            <h1>listsinceblock - Zcash 6.12.1 RPC</h1>
           
             <pre>listsinceblock ( &#34;blockhash&#34; target-confirmations includeWatchonly includeRemoved includeChange asOfHeight )
 

--- a/listsinceblock.html
+++ b/listsinceblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listsinceblock">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listsinceblock">
     <meta name="author" content="">
-    <title>listsinceblock - Zcash 6.12.1 RPC Docs</title>
+    <title>listsinceblock - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listsinceblock - Zcash 6.12.1 RPC</h1>
+            <h1>listsinceblock - Zcash 6.12.2 RPC</h1>
           
             <pre>listsinceblock ( &#34;blockhash&#34; target-confirmations includeWatchonly includeRemoved includeChange asOfHeight )
 

--- a/listsinceblock.html
+++ b/listsinceblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listsinceblock">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listsinceblock">
     <meta name="author" content="">
-    <title>listsinceblock - Zcash 6.2.0 RPC Docs</title>
+    <title>listsinceblock - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listsinceblock - Zcash 6.2.0 RPC</h1>
+            <h1>listsinceblock - Zcash 6.10.0 RPC</h1>
           
             <pre>listsinceblock ( &#34;blockhash&#34; target-confirmations includeWatchonly includeRemoved includeChange asOfHeight )
 

--- a/listtransactions.html
+++ b/listtransactions.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listtransactions">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listtransactions">
     <meta name="author" content="">
-    <title>listtransactions - Zcash 6.2.0 RPC Docs</title>
+    <title>listtransactions - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listtransactions - Zcash 6.2.0 RPC</h1>
+            <h1>listtransactions - Zcash 6.10.0 RPC</h1>
           
             <pre>listtransactions ( &#34;dummy&#34; count from includeWatchonly asOfHeight)
 

--- a/listtransactions.html
+++ b/listtransactions.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listtransactions">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listtransactions">
     <meta name="author" content="">
-    <title>listtransactions - Zcash 6.12.1 RPC Docs</title>
+    <title>listtransactions - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listtransactions - Zcash 6.12.1 RPC</h1>
+            <h1>listtransactions - Zcash 6.12.2 RPC</h1>
           
             <pre>listtransactions ( &#34;dummy&#34; count from includeWatchonly asOfHeight)
 

--- a/listtransactions.html
+++ b/listtransactions.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listtransactions">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listtransactions">
     <meta name="author" content="">
-    <title>listtransactions - Zcash 6.10.0 RPC Docs</title>
+    <title>listtransactions - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listtransactions - Zcash 6.10.0 RPC</h1>
+            <h1>listtransactions - Zcash 6.12.1 RPC</h1>
           
             <pre>listtransactions ( &#34;dummy&#34; count from includeWatchonly asOfHeight)
 

--- a/listunspent.html
+++ b/listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - listunspent">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - listunspent">
     <meta name="author" content="">
-    <title>listunspent - Zcash 6.2.0 RPC Docs</title>
+    <title>listunspent - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listunspent - Zcash 6.2.0 RPC</h1>
+            <h1>listunspent - Zcash 6.10.0 RPC</h1>
           
             <pre>listunspent ( minconf maxconf [&#34;address&#34;,...] includeUnsafe queryOptions asOfHeight )
 

--- a/listunspent.html
+++ b/listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - listunspent">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - listunspent">
     <meta name="author" content="">
-    <title>listunspent - Zcash 6.12.1 RPC Docs</title>
+    <title>listunspent - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listunspent - Zcash 6.12.1 RPC</h1>
+            <h1>listunspent - Zcash 6.12.2 RPC</h1>
           
             <pre>listunspent ( minconf maxconf [&#34;address&#34;,...] includeUnsafe queryOptions asOfHeight )
 

--- a/listunspent.html
+++ b/listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - listunspent">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - listunspent">
     <meta name="author" content="">
-    <title>listunspent - Zcash 6.10.0 RPC Docs</title>
+    <title>listunspent - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>listunspent - Zcash 6.10.0 RPC</h1>
+            <h1>listunspent - Zcash 6.12.1 RPC</h1>
           
             <pre>listunspent ( minconf maxconf [&#34;address&#34;,...] includeUnsafe queryOptions asOfHeight )
 

--- a/lockunspent.html
+++ b/lockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - lockunspent">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - lockunspent">
     <meta name="author" content="">
-    <title>lockunspent - Zcash 6.12.1 RPC Docs</title>
+    <title>lockunspent - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>lockunspent - Zcash 6.12.1 RPC</h1>
+            <h1>lockunspent - Zcash 6.12.2 RPC</h1>
           
             <pre>lockunspent unlock [{&#34;txid&#34;:&#34;txid&#34;,&#34;vout&#34;:n},...]
 

--- a/lockunspent.html
+++ b/lockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - lockunspent">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - lockunspent">
     <meta name="author" content="">
-    <title>lockunspent - Zcash 6.10.0 RPC Docs</title>
+    <title>lockunspent - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>lockunspent - Zcash 6.10.0 RPC</h1>
+            <h1>lockunspent - Zcash 6.12.1 RPC</h1>
           
             <pre>lockunspent unlock [{&#34;txid&#34;:&#34;txid&#34;,&#34;vout&#34;:n},...]
 

--- a/lockunspent.html
+++ b/lockunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - lockunspent">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - lockunspent">
     <meta name="author" content="">
-    <title>lockunspent - Zcash 6.2.0 RPC Docs</title>
+    <title>lockunspent - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>lockunspent - Zcash 6.2.0 RPC</h1>
+            <h1>lockunspent - Zcash 6.10.0 RPC</h1>
           
             <pre>lockunspent unlock [{&#34;txid&#34;:&#34;txid&#34;,&#34;vout&#34;:n},...]
 

--- a/ping.html
+++ b/ping.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - ping">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - ping">
     <meta name="author" content="">
-    <title>ping - Zcash 6.2.0 RPC Docs</title>
+    <title>ping - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>ping - Zcash 6.2.0 RPC</h1>
+            <h1>ping - Zcash 6.10.0 RPC</h1>
           
             <pre>ping
 

--- a/ping.html
+++ b/ping.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - ping">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - ping">
     <meta name="author" content="">
-    <title>ping - Zcash 6.12.1 RPC Docs</title>
+    <title>ping - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>ping - Zcash 6.12.1 RPC</h1>
+            <h1>ping - Zcash 6.12.2 RPC</h1>
           
             <pre>ping
 

--- a/ping.html
+++ b/ping.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - ping">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - ping">
     <meta name="author" content="">
-    <title>ping - Zcash 6.10.0 RPC Docs</title>
+    <title>ping - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>ping - Zcash 6.10.0 RPC</h1>
+            <h1>ping - Zcash 6.12.1 RPC</h1>
           
             <pre>ping
 

--- a/prioritisetransaction.html
+++ b/prioritisetransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - prioritisetransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - prioritisetransaction">
     <meta name="author" content="">
-    <title>prioritisetransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>prioritisetransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>prioritisetransaction - Zcash 6.10.0 RPC</h1>
+            <h1>prioritisetransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>prioritisetransaction &lt;txid&gt; &lt;priority delta&gt; &lt;fee delta&gt;
 Accepts the transaction into mined blocks at a higher (or lower) priority

--- a/prioritisetransaction.html
+++ b/prioritisetransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - prioritisetransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - prioritisetransaction">
     <meta name="author" content="">
-    <title>prioritisetransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>prioritisetransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>prioritisetransaction - Zcash 6.12.1 RPC</h1>
+            <h1>prioritisetransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>prioritisetransaction &lt;txid&gt; &lt;priority delta&gt; &lt;fee delta&gt;
 Accepts the transaction into mined blocks at a higher (or lower) priority

--- a/prioritisetransaction.html
+++ b/prioritisetransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - prioritisetransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - prioritisetransaction">
     <meta name="author" content="">
-    <title>prioritisetransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>prioritisetransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>prioritisetransaction - Zcash 6.2.0 RPC</h1>
+            <h1>prioritisetransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>prioritisetransaction &lt;txid&gt; &lt;priority delta&gt; &lt;fee delta&gt;
 Accepts the transaction into mined blocks at a higher (or lower) priority

--- a/script/template.html
+++ b/script/template.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
     <meta name="author" content="">
-    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.1 RPC Docs</title>
+    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.1 RPC</h1>
+            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.2 RPC</h1>
           {{if .Command}}
             <pre>{{.Command.Description}}</pre>
             <hr>

--- a/script/template.html
+++ b/script/template.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
     <meta name="author" content="">
-    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.10.0 RPC Docs</title>
+    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.10.0 RPC</h1>
+            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.12.1 RPC</h1>
           {{if .Command}}
             <pre>{{.Command.Description}}</pre>
             <hr>

--- a/script/template.html
+++ b/script/template.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs{{if .Command}} - {{.Command.Name}}{{end}}">
     <meta name="author" content="">
-    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.2.0 RPC Docs</title>
+    <title>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.2.0 RPC</h1>
+            <h1>{{if .Command}}{{.Command.Name}} - {{end}}Zcash 6.10.0 RPC</h1>
           {{if .Command}}
             <pre>{{.Command.Description}}</pre>
             <hr>

--- a/sendmany.html
+++ b/sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - sendmany">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendmany">
     <meta name="author" content="">
-    <title>sendmany - Zcash 6.2.0 RPC Docs</title>
+    <title>sendmany - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendmany - Zcash 6.2.0 RPC</h1>
+            <h1>sendmany - Zcash 6.10.0 RPC</h1>
           
             <pre>sendmany &#34;&#34; {&#34;address&#34;:amount,...} ( minconf &#34;comment&#34; [&#34;address&#34;,...] )
 

--- a/sendmany.html
+++ b/sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendmany">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - sendmany">
     <meta name="author" content="">
-    <title>sendmany - Zcash 6.12.1 RPC Docs</title>
+    <title>sendmany - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendmany - Zcash 6.12.1 RPC</h1>
+            <h1>sendmany - Zcash 6.12.2 RPC</h1>
           
             <pre>sendmany &#34;&#34; {&#34;address&#34;:amount,...} ( minconf &#34;comment&#34; [&#34;address&#34;,...] )
 

--- a/sendmany.html
+++ b/sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendmany">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendmany">
     <meta name="author" content="">
-    <title>sendmany - Zcash 6.10.0 RPC Docs</title>
+    <title>sendmany - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendmany - Zcash 6.10.0 RPC</h1>
+            <h1>sendmany - Zcash 6.12.1 RPC</h1>
           
             <pre>sendmany &#34;&#34; {&#34;address&#34;:amount,...} ( minconf &#34;comment&#34; [&#34;address&#34;,...] )
 

--- a/sendrawtransaction.html
+++ b/sendrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendrawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendrawtransaction">
     <meta name="author" content="">
-    <title>sendrawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>sendrawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendrawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>sendrawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>sendrawtransaction &#34;hexstring&#34; ( allowhighfees )
 

--- a/sendrawtransaction.html
+++ b/sendrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendrawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - sendrawtransaction">
     <meta name="author" content="">
-    <title>sendrawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>sendrawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendrawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>sendrawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>sendrawtransaction &#34;hexstring&#34; ( allowhighfees )
 

--- a/sendrawtransaction.html
+++ b/sendrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - sendrawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendrawtransaction">
     <meta name="author" content="">
-    <title>sendrawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>sendrawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendrawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>sendrawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>sendrawtransaction &#34;hexstring&#34; ( allowhighfees )
 

--- a/sendtoaddress.html
+++ b/sendtoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendtoaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendtoaddress">
     <meta name="author" content="">
-    <title>sendtoaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>sendtoaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendtoaddress - Zcash 6.10.0 RPC</h1>
+            <h1>sendtoaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>sendtoaddress &#34;zcashaddress&#34; amount ( &#34;comment&#34; &#34;comment-to&#34; subtractfeefromamount )
 

--- a/sendtoaddress.html
+++ b/sendtoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - sendtoaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - sendtoaddress">
     <meta name="author" content="">
-    <title>sendtoaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>sendtoaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendtoaddress - Zcash 6.12.1 RPC</h1>
+            <h1>sendtoaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>sendtoaddress &#34;zcashaddress&#34; amount ( &#34;comment&#34; &#34;comment-to&#34; subtractfeefromamount )
 

--- a/sendtoaddress.html
+++ b/sendtoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - sendtoaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - sendtoaddress">
     <meta name="author" content="">
-    <title>sendtoaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>sendtoaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>sendtoaddress - Zcash 6.2.0 RPC</h1>
+            <h1>sendtoaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>sendtoaddress &#34;zcashaddress&#34; amount ( &#34;comment&#34; &#34;comment-to&#34; subtractfeefromamount )
 

--- a/setban.html
+++ b/setban.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - setban">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - setban">
     <meta name="author" content="">
-    <title>setban - Zcash 6.2.0 RPC Docs</title>
+    <title>setban - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setban - Zcash 6.2.0 RPC</h1>
+            <h1>setban - Zcash 6.10.0 RPC</h1>
           
             <pre>setban &#34;ip(/netmask)&#34; &#34;add|remove&#34; (bantime) (absolute)
 

--- a/setban.html
+++ b/setban.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - setban">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - setban">
     <meta name="author" content="">
-    <title>setban - Zcash 6.10.0 RPC Docs</title>
+    <title>setban - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setban - Zcash 6.10.0 RPC</h1>
+            <h1>setban - Zcash 6.12.1 RPC</h1>
           
             <pre>setban &#34;ip(/netmask)&#34; &#34;add|remove&#34; (bantime) (absolute)
 

--- a/setban.html
+++ b/setban.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - setban">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - setban">
     <meta name="author" content="">
-    <title>setban - Zcash 6.12.1 RPC Docs</title>
+    <title>setban - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setban - Zcash 6.12.1 RPC</h1>
+            <h1>setban - Zcash 6.12.2 RPC</h1>
           
             <pre>setban &#34;ip(/netmask)&#34; &#34;add|remove&#34; (bantime) (absolute)
 

--- a/setgenerate.html
+++ b/setgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - setgenerate">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - setgenerate">
     <meta name="author" content="">
-    <title>setgenerate - Zcash 6.10.0 RPC Docs</title>
+    <title>setgenerate - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setgenerate - Zcash 6.10.0 RPC</h1>
+            <h1>setgenerate - Zcash 6.12.1 RPC</h1>
           
             <pre>setgenerate generate ( genproclimit )
 

--- a/setgenerate.html
+++ b/setgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - setgenerate">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - setgenerate">
     <meta name="author" content="">
-    <title>setgenerate - Zcash 6.12.1 RPC Docs</title>
+    <title>setgenerate - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setgenerate - Zcash 6.12.1 RPC</h1>
+            <h1>setgenerate - Zcash 6.12.2 RPC</h1>
           
             <pre>setgenerate generate ( genproclimit )
 

--- a/setgenerate.html
+++ b/setgenerate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - setgenerate">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - setgenerate">
     <meta name="author" content="">
-    <title>setgenerate - Zcash 6.2.0 RPC Docs</title>
+    <title>setgenerate - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setgenerate - Zcash 6.2.0 RPC</h1>
+            <h1>setgenerate - Zcash 6.10.0 RPC</h1>
           
             <pre>setgenerate generate ( genproclimit )
 

--- a/setlogfilter.html
+++ b/setlogfilter.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - setlogfilter">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - setlogfilter">
     <meta name="author" content="">
-    <title>setlogfilter - Zcash 6.10.0 RPC Docs</title>
+    <title>setlogfilter - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setlogfilter - Zcash 6.10.0 RPC</h1>
+            <h1>setlogfilter - Zcash 6.12.1 RPC</h1>
           
             <pre>setlogfilter &#34;directives&#34;
 

--- a/setlogfilter.html
+++ b/setlogfilter.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - setlogfilter">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - setlogfilter">
     <meta name="author" content="">
-    <title>setlogfilter - Zcash 6.2.0 RPC Docs</title>
+    <title>setlogfilter - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setlogfilter - Zcash 6.2.0 RPC</h1>
+            <h1>setlogfilter - Zcash 6.10.0 RPC</h1>
           
             <pre>setlogfilter &#34;directives&#34;
 

--- a/setlogfilter.html
+++ b/setlogfilter.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - setlogfilter">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - setlogfilter">
     <meta name="author" content="">
-    <title>setlogfilter - Zcash 6.12.1 RPC Docs</title>
+    <title>setlogfilter - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>setlogfilter - Zcash 6.12.1 RPC</h1>
+            <h1>setlogfilter - Zcash 6.12.2 RPC</h1>
           
             <pre>setlogfilter &#34;directives&#34;
 

--- a/settxfee.html
+++ b/settxfee.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - settxfee">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - settxfee">
     <meta name="author" content="">
-    <title>settxfee - Zcash 6.2.0 RPC Docs</title>
+    <title>settxfee - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>settxfee - Zcash 6.2.0 RPC</h1>
+            <h1>settxfee - Zcash 6.10.0 RPC</h1>
           
             <pre>settxfee amount
 

--- a/settxfee.html
+++ b/settxfee.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - settxfee">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - settxfee">
     <meta name="author" content="">
-    <title>settxfee - Zcash 6.10.0 RPC Docs</title>
+    <title>settxfee - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>settxfee - Zcash 6.10.0 RPC</h1>
+            <h1>settxfee - Zcash 6.12.1 RPC</h1>
           
             <pre>settxfee amount
 

--- a/settxfee.html
+++ b/settxfee.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - settxfee">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - settxfee">
     <meta name="author" content="">
-    <title>settxfee - Zcash 6.12.1 RPC Docs</title>
+    <title>settxfee - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>settxfee - Zcash 6.12.1 RPC</h1>
+            <h1>settxfee - Zcash 6.12.2 RPC</h1>
           
             <pre>settxfee amount
 

--- a/signmessage.html
+++ b/signmessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - signmessage">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - signmessage">
     <meta name="author" content="">
-    <title>signmessage - Zcash 6.10.0 RPC Docs</title>
+    <title>signmessage - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signmessage - Zcash 6.10.0 RPC</h1>
+            <h1>signmessage - Zcash 6.12.1 RPC</h1>
           
             <pre>signmessage &#34;t-addr&#34; &#34;message&#34;
 

--- a/signmessage.html
+++ b/signmessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - signmessage">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - signmessage">
     <meta name="author" content="">
-    <title>signmessage - Zcash 6.12.1 RPC Docs</title>
+    <title>signmessage - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signmessage - Zcash 6.12.1 RPC</h1>
+            <h1>signmessage - Zcash 6.12.2 RPC</h1>
           
             <pre>signmessage &#34;t-addr&#34; &#34;message&#34;
 

--- a/signmessage.html
+++ b/signmessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - signmessage">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - signmessage">
     <meta name="author" content="">
-    <title>signmessage - Zcash 6.2.0 RPC Docs</title>
+    <title>signmessage - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signmessage - Zcash 6.2.0 RPC</h1>
+            <h1>signmessage - Zcash 6.10.0 RPC</h1>
           
             <pre>signmessage &#34;t-addr&#34; &#34;message&#34;
 

--- a/signrawtransaction.html
+++ b/signrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - signrawtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - signrawtransaction">
     <meta name="author" content="">
-    <title>signrawtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>signrawtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signrawtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>signrawtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>signrawtransaction &#34;hexstring&#34; ( [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n,&#34;scriptPubKey&#34;:&#34;hex&#34;,&#34;redeemScript&#34;:&#34;hex&#34;},...] [&#34;privatekey1&#34;,...] sighashtype )
 

--- a/signrawtransaction.html
+++ b/signrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - signrawtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - signrawtransaction">
     <meta name="author" content="">
-    <title>signrawtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>signrawtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signrawtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>signrawtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>signrawtransaction &#34;hexstring&#34; ( [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n,&#34;scriptPubKey&#34;:&#34;hex&#34;,&#34;redeemScript&#34;:&#34;hex&#34;},...] [&#34;privatekey1&#34;,...] sighashtype )
 

--- a/signrawtransaction.html
+++ b/signrawtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - signrawtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - signrawtransaction">
     <meta name="author" content="">
-    <title>signrawtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>signrawtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>signrawtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>signrawtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>signrawtransaction &#34;hexstring&#34; ( [{&#34;txid&#34;:&#34;id&#34;,&#34;vout&#34;:n,&#34;scriptPubKey&#34;:&#34;hex&#34;,&#34;redeemScript&#34;:&#34;hex&#34;},...] [&#34;privatekey1&#34;,...] sighashtype )
 

--- a/stop.html
+++ b/stop.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - stop">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - stop">
     <meta name="author" content="">
-    <title>stop - Zcash 6.2.0 RPC Docs</title>
+    <title>stop - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>stop - Zcash 6.2.0 RPC</h1>
+            <h1>stop - Zcash 6.10.0 RPC</h1>
           
             <pre>stop
 

--- a/stop.html
+++ b/stop.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - stop">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - stop">
     <meta name="author" content="">
-    <title>stop - Zcash 6.12.1 RPC Docs</title>
+    <title>stop - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>stop - Zcash 6.12.1 RPC</h1>
+            <h1>stop - Zcash 6.12.2 RPC</h1>
           
             <pre>stop
 

--- a/stop.html
+++ b/stop.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - stop">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - stop">
     <meta name="author" content="">
-    <title>stop - Zcash 6.10.0 RPC Docs</title>
+    <title>stop - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>stop - Zcash 6.10.0 RPC</h1>
+            <h1>stop - Zcash 6.12.1 RPC</h1>
           
             <pre>stop
 

--- a/submitblock.html
+++ b/submitblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - submitblock">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - submitblock">
     <meta name="author" content="">
-    <title>submitblock - Zcash 6.2.0 RPC Docs</title>
+    <title>submitblock - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>submitblock - Zcash 6.2.0 RPC</h1>
+            <h1>submitblock - Zcash 6.10.0 RPC</h1>
           
             <pre>submitblock &#34;hexdata&#34; ( &#34;jsonparametersobject&#34; )
 

--- a/submitblock.html
+++ b/submitblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - submitblock">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - submitblock">
     <meta name="author" content="">
-    <title>submitblock - Zcash 6.10.0 RPC Docs</title>
+    <title>submitblock - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>submitblock - Zcash 6.10.0 RPC</h1>
+            <h1>submitblock - Zcash 6.12.1 RPC</h1>
           
             <pre>submitblock &#34;hexdata&#34; ( &#34;jsonparametersobject&#34; )
 

--- a/submitblock.html
+++ b/submitblock.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - submitblock">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - submitblock">
     <meta name="author" content="">
-    <title>submitblock - Zcash 6.12.1 RPC Docs</title>
+    <title>submitblock - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>submitblock - Zcash 6.12.1 RPC</h1>
+            <h1>submitblock - Zcash 6.12.2 RPC</h1>
           
             <pre>submitblock &#34;hexdata&#34; ( &#34;jsonparametersobject&#34; )
 

--- a/validateaddress.html
+++ b/validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - validateaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - validateaddress">
     <meta name="author" content="">
-    <title>validateaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>validateaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>validateaddress - Zcash 6.10.0 RPC</h1>
+            <h1>validateaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>validateaddress &#34;zcashaddress&#34;
 

--- a/validateaddress.html
+++ b/validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - validateaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - validateaddress">
     <meta name="author" content="">
-    <title>validateaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>validateaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>validateaddress - Zcash 6.2.0 RPC</h1>
+            <h1>validateaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>validateaddress &#34;zcashaddress&#34;
 

--- a/validateaddress.html
+++ b/validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - validateaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - validateaddress">
     <meta name="author" content="">
-    <title>validateaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>validateaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>validateaddress - Zcash 6.12.1 RPC</h1>
+            <h1>validateaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>validateaddress &#34;zcashaddress&#34;
 

--- a/verifychain.html
+++ b/verifychain.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifychain">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - verifychain">
     <meta name="author" content="">
-    <title>verifychain - Zcash 6.12.1 RPC Docs</title>
+    <title>verifychain - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifychain - Zcash 6.12.1 RPC</h1>
+            <h1>verifychain - Zcash 6.12.2 RPC</h1>
           
             <pre>verifychain ( checklevel numblocks )
 

--- a/verifychain.html
+++ b/verifychain.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifychain">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifychain">
     <meta name="author" content="">
-    <title>verifychain - Zcash 6.10.0 RPC Docs</title>
+    <title>verifychain - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifychain - Zcash 6.10.0 RPC</h1>
+            <h1>verifychain - Zcash 6.12.1 RPC</h1>
           
             <pre>verifychain ( checklevel numblocks )
 

--- a/verifychain.html
+++ b/verifychain.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - verifychain">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifychain">
     <meta name="author" content="">
-    <title>verifychain - Zcash 6.2.0 RPC Docs</title>
+    <title>verifychain - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifychain - Zcash 6.2.0 RPC</h1>
+            <h1>verifychain - Zcash 6.10.0 RPC</h1>
           
             <pre>verifychain ( checklevel numblocks )
 

--- a/verifymessage.html
+++ b/verifymessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - verifymessage">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifymessage">
     <meta name="author" content="">
-    <title>verifymessage - Zcash 6.2.0 RPC Docs</title>
+    <title>verifymessage - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifymessage - Zcash 6.2.0 RPC</h1>
+            <h1>verifymessage - Zcash 6.10.0 RPC</h1>
           
             <pre>verifymessage &#34;zcashaddress&#34; &#34;signature&#34; &#34;message&#34;
 

--- a/verifymessage.html
+++ b/verifymessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifymessage">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifymessage">
     <meta name="author" content="">
-    <title>verifymessage - Zcash 6.10.0 RPC Docs</title>
+    <title>verifymessage - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifymessage - Zcash 6.10.0 RPC</h1>
+            <h1>verifymessage - Zcash 6.12.1 RPC</h1>
           
             <pre>verifymessage &#34;zcashaddress&#34; &#34;signature&#34; &#34;message&#34;
 

--- a/verifymessage.html
+++ b/verifymessage.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifymessage">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - verifymessage">
     <meta name="author" content="">
-    <title>verifymessage - Zcash 6.12.1 RPC Docs</title>
+    <title>verifymessage - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifymessage - Zcash 6.12.1 RPC</h1>
+            <h1>verifymessage - Zcash 6.12.2 RPC</h1>
           
             <pre>verifymessage &#34;zcashaddress&#34; &#34;signature&#34; &#34;message&#34;
 

--- a/verifytxoutproof.html
+++ b/verifytxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifytxoutproof">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - verifytxoutproof">
     <meta name="author" content="">
-    <title>verifytxoutproof - Zcash 6.12.1 RPC Docs</title>
+    <title>verifytxoutproof - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifytxoutproof - Zcash 6.12.1 RPC</h1>
+            <h1>verifytxoutproof - Zcash 6.12.2 RPC</h1>
           
             <pre>verifytxoutproof &#34;proof&#34;
 

--- a/verifytxoutproof.html
+++ b/verifytxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifytxoutproof">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - verifytxoutproof">
     <meta name="author" content="">
-    <title>verifytxoutproof - Zcash 6.10.0 RPC Docs</title>
+    <title>verifytxoutproof - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifytxoutproof - Zcash 6.10.0 RPC</h1>
+            <h1>verifytxoutproof - Zcash 6.12.1 RPC</h1>
           
             <pre>verifytxoutproof &#34;proof&#34;
 

--- a/verifytxoutproof.html
+++ b/verifytxoutproof.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - verifytxoutproof">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - verifytxoutproof">
     <meta name="author" content="">
-    <title>verifytxoutproof - Zcash 6.2.0 RPC Docs</title>
+    <title>verifytxoutproof - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>verifytxoutproof - Zcash 6.2.0 RPC</h1>
+            <h1>verifytxoutproof - Zcash 6.10.0 RPC</h1>
           
             <pre>verifytxoutproof &#34;proof&#34;
 

--- a/walletconfirmbackup.html
+++ b/walletconfirmbackup.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - walletconfirmbackup">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - walletconfirmbackup">
     <meta name="author" content="">
-    <title>walletconfirmbackup - Zcash 6.10.0 RPC Docs</title>
+    <title>walletconfirmbackup - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>walletconfirmbackup - Zcash 6.10.0 RPC</h1>
+            <h1>walletconfirmbackup - Zcash 6.12.1 RPC</h1>
           
             <pre>walletconfirmbackup &#34;emergency recovery phrase&#34;
 

--- a/walletconfirmbackup.html
+++ b/walletconfirmbackup.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - walletconfirmbackup">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - walletconfirmbackup">
     <meta name="author" content="">
-    <title>walletconfirmbackup - Zcash 6.12.1 RPC Docs</title>
+    <title>walletconfirmbackup - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>walletconfirmbackup - Zcash 6.12.1 RPC</h1>
+            <h1>walletconfirmbackup - Zcash 6.12.2 RPC</h1>
           
             <pre>walletconfirmbackup &#34;emergency recovery phrase&#34;
 

--- a/walletconfirmbackup.html
+++ b/walletconfirmbackup.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - walletconfirmbackup">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - walletconfirmbackup">
     <meta name="author" content="">
-    <title>walletconfirmbackup - Zcash 6.2.0 RPC Docs</title>
+    <title>walletconfirmbackup - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>walletconfirmbackup - Zcash 6.2.0 RPC</h1>
+            <h1>walletconfirmbackup - Zcash 6.10.0 RPC</h1>
           
             <pre>walletconfirmbackup &#34;emergency recovery phrase&#34;
 

--- a/z_converttex.html
+++ b/z_converttex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_converttex">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_converttex">
     <meta name="author" content="">
-    <title>z_converttex - Zcash 6.12.1 RPC Docs</title>
+    <title>z_converttex - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_converttex - Zcash 6.12.1 RPC</h1>
+            <h1>z_converttex - Zcash 6.12.2 RPC</h1>
           
             <pre>z_converttex ( &#34;transparentaddress&#34; )
 

--- a/z_converttex.html
+++ b/z_converttex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_converttex">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_converttex">
     <meta name="author" content="">
-    <title>z_converttex - Zcash 6.2.0 RPC Docs</title>
+    <title>z_converttex - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_converttex - Zcash 6.2.0 RPC</h1>
+            <h1>z_converttex - Zcash 6.10.0 RPC</h1>
           
             <pre>z_converttex ( &#34;transparentaddress&#34; )
 

--- a/z_converttex.html
+++ b/z_converttex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_converttex">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_converttex">
     <meta name="author" content="">
-    <title>z_converttex - Zcash 6.10.0 RPC Docs</title>
+    <title>z_converttex - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_converttex - Zcash 6.10.0 RPC</h1>
+            <h1>z_converttex - Zcash 6.12.1 RPC</h1>
           
             <pre>z_converttex ( &#34;transparentaddress&#34; )
 

--- a/z_exportkey.html
+++ b/z_exportkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportkey">
     <meta name="author" content="">
-    <title>z_exportkey - Zcash 6.10.0 RPC Docs</title>
+    <title>z_exportkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportkey - Zcash 6.10.0 RPC</h1>
+            <h1>z_exportkey - Zcash 6.12.1 RPC</h1>
           
             <pre>z_exportkey &#34;zaddr&#34;
 

--- a/z_exportkey.html
+++ b/z_exportkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_exportkey">
     <meta name="author" content="">
-    <title>z_exportkey - Zcash 6.12.1 RPC Docs</title>
+    <title>z_exportkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportkey - Zcash 6.12.1 RPC</h1>
+            <h1>z_exportkey - Zcash 6.12.2 RPC</h1>
           
             <pre>z_exportkey &#34;zaddr&#34;
 

--- a/z_exportkey.html
+++ b/z_exportkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_exportkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportkey">
     <meta name="author" content="">
-    <title>z_exportkey - Zcash 6.2.0 RPC Docs</title>
+    <title>z_exportkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportkey - Zcash 6.2.0 RPC</h1>
+            <h1>z_exportkey - Zcash 6.10.0 RPC</h1>
           
             <pre>z_exportkey &#34;zaddr&#34;
 

--- a/z_exportviewingkey.html
+++ b/z_exportviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportviewingkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportviewingkey">
     <meta name="author" content="">
-    <title>z_exportviewingkey - Zcash 6.10.0 RPC Docs</title>
+    <title>z_exportviewingkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportviewingkey - Zcash 6.10.0 RPC</h1>
+            <h1>z_exportviewingkey - Zcash 6.12.1 RPC</h1>
           
             <pre>z_exportviewingkey &#34;zaddr&#34;
 

--- a/z_exportviewingkey.html
+++ b/z_exportviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportviewingkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_exportviewingkey">
     <meta name="author" content="">
-    <title>z_exportviewingkey - Zcash 6.12.1 RPC Docs</title>
+    <title>z_exportviewingkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportviewingkey - Zcash 6.12.1 RPC</h1>
+            <h1>z_exportviewingkey - Zcash 6.12.2 RPC</h1>
           
             <pre>z_exportviewingkey &#34;zaddr&#34;
 

--- a/z_exportviewingkey.html
+++ b/z_exportviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_exportviewingkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportviewingkey">
     <meta name="author" content="">
-    <title>z_exportviewingkey - Zcash 6.2.0 RPC Docs</title>
+    <title>z_exportviewingkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportviewingkey - Zcash 6.2.0 RPC</h1>
+            <h1>z_exportviewingkey - Zcash 6.10.0 RPC</h1>
           
             <pre>z_exportviewingkey &#34;zaddr&#34;
 

--- a/z_exportwallet.html
+++ b/z_exportwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportwallet">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportwallet">
     <meta name="author" content="">
-    <title>z_exportwallet - Zcash 6.10.0 RPC Docs</title>
+    <title>z_exportwallet - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportwallet - Zcash 6.10.0 RPC</h1>
+            <h1>z_exportwallet - Zcash 6.12.1 RPC</h1>
           
             <pre>z_exportwallet &#34;filename&#34;
 

--- a/z_exportwallet.html
+++ b/z_exportwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_exportwallet">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_exportwallet">
     <meta name="author" content="">
-    <title>z_exportwallet - Zcash 6.2.0 RPC Docs</title>
+    <title>z_exportwallet - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportwallet - Zcash 6.2.0 RPC</h1>
+            <h1>z_exportwallet - Zcash 6.10.0 RPC</h1>
           
             <pre>z_exportwallet &#34;filename&#34;
 

--- a/z_exportwallet.html
+++ b/z_exportwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_exportwallet">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_exportwallet">
     <meta name="author" content="">
-    <title>z_exportwallet - Zcash 6.12.1 RPC Docs</title>
+    <title>z_exportwallet - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_exportwallet - Zcash 6.12.1 RPC</h1>
+            <h1>z_exportwallet - Zcash 6.12.2 RPC</h1>
           
             <pre>z_exportwallet &#34;filename&#34;
 

--- a/z_getaddressforaccount.html
+++ b/z_getaddressforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getaddressforaccount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getaddressforaccount">
     <meta name="author" content="">
-    <title>z_getaddressforaccount - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getaddressforaccount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getaddressforaccount - Zcash 6.10.0 RPC</h1>
+            <h1>z_getaddressforaccount - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getaddressforaccount account ( [&#34;receiver_type&#34;, ...] diversifier_index )
 

--- a/z_getaddressforaccount.html
+++ b/z_getaddressforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getaddressforaccount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getaddressforaccount">
     <meta name="author" content="">
-    <title>z_getaddressforaccount - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getaddressforaccount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getaddressforaccount - Zcash 6.12.1 RPC</h1>
+            <h1>z_getaddressforaccount - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getaddressforaccount account ( [&#34;receiver_type&#34;, ...] diversifier_index )
 

--- a/z_getaddressforaccount.html
+++ b/z_getaddressforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getaddressforaccount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getaddressforaccount">
     <meta name="author" content="">
-    <title>z_getaddressforaccount - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getaddressforaccount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getaddressforaccount - Zcash 6.2.0 RPC</h1>
+            <h1>z_getaddressforaccount - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getaddressforaccount account ( [&#34;receiver_type&#34;, ...] diversifier_index )
 

--- a/z_getbalance.html
+++ b/z_getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalance">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getbalance">
     <meta name="author" content="">
-    <title>z_getbalance - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getbalance - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalance - Zcash 6.12.1 RPC</h1>
+            <h1>z_getbalance - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getbalance &#34;address&#34; ( minconf inZat )
 

--- a/z_getbalance.html
+++ b/z_getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalance">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalance">
     <meta name="author" content="">
-    <title>z_getbalance - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getbalance - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalance - Zcash 6.10.0 RPC</h1>
+            <h1>z_getbalance - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getbalance &#34;address&#34; ( minconf inZat )
 

--- a/z_getbalance.html
+++ b/z_getbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getbalance">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalance">
     <meta name="author" content="">
-    <title>z_getbalance - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getbalance - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalance - Zcash 6.2.0 RPC</h1>
+            <h1>z_getbalance - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getbalance &#34;address&#34; ( minconf inZat )
 

--- a/z_getbalanceforaccount.html
+++ b/z_getbalanceforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getbalanceforaccount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalanceforaccount">
     <meta name="author" content="">
-    <title>z_getbalanceforaccount - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getbalanceforaccount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforaccount - Zcash 6.2.0 RPC</h1>
+            <h1>z_getbalanceforaccount - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getbalanceforaccount account ( minconf asOfHeight )
 

--- a/z_getbalanceforaccount.html
+++ b/z_getbalanceforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalanceforaccount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalanceforaccount">
     <meta name="author" content="">
-    <title>z_getbalanceforaccount - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getbalanceforaccount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforaccount - Zcash 6.10.0 RPC</h1>
+            <h1>z_getbalanceforaccount - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getbalanceforaccount account ( minconf asOfHeight )
 

--- a/z_getbalanceforaccount.html
+++ b/z_getbalanceforaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalanceforaccount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getbalanceforaccount">
     <meta name="author" content="">
-    <title>z_getbalanceforaccount - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getbalanceforaccount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforaccount - Zcash 6.12.1 RPC</h1>
+            <h1>z_getbalanceforaccount - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getbalanceforaccount account ( minconf asOfHeight )
 

--- a/z_getbalanceforviewingkey.html
+++ b/z_getbalanceforviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalanceforviewingkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalanceforviewingkey">
     <meta name="author" content="">
-    <title>z_getbalanceforviewingkey - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getbalanceforviewingkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforviewingkey - Zcash 6.10.0 RPC</h1>
+            <h1>z_getbalanceforviewingkey - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getbalanceforviewingkey &#34;fvk&#34; ( minconf asOfHeight )
 

--- a/z_getbalanceforviewingkey.html
+++ b/z_getbalanceforviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getbalanceforviewingkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getbalanceforviewingkey">
     <meta name="author" content="">
-    <title>z_getbalanceforviewingkey - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getbalanceforviewingkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforviewingkey - Zcash 6.2.0 RPC</h1>
+            <h1>z_getbalanceforviewingkey - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getbalanceforviewingkey &#34;fvk&#34; ( minconf asOfHeight )
 

--- a/z_getbalanceforviewingkey.html
+++ b/z_getbalanceforviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getbalanceforviewingkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getbalanceforviewingkey">
     <meta name="author" content="">
-    <title>z_getbalanceforviewingkey - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getbalanceforviewingkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getbalanceforviewingkey - Zcash 6.12.1 RPC</h1>
+            <h1>z_getbalanceforviewingkey - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getbalanceforviewingkey &#34;fvk&#34; ( minconf asOfHeight )
 

--- a/z_getmigrationstatus.html
+++ b/z_getmigrationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getmigrationstatus">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getmigrationstatus">
     <meta name="author" content="">
-    <title>z_getmigrationstatus - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getmigrationstatus - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getmigrationstatus - Zcash 6.2.0 RPC</h1>
+            <h1>z_getmigrationstatus - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getmigrationstatus ( asOfHeight )
 Returns information about the status of the Sprout to Sapling migration.

--- a/z_getmigrationstatus.html
+++ b/z_getmigrationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getmigrationstatus">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getmigrationstatus">
     <meta name="author" content="">
-    <title>z_getmigrationstatus - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getmigrationstatus - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getmigrationstatus - Zcash 6.10.0 RPC</h1>
+            <h1>z_getmigrationstatus - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getmigrationstatus ( asOfHeight )
 Returns information about the status of the Sprout to Sapling migration.

--- a/z_getmigrationstatus.html
+++ b/z_getmigrationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getmigrationstatus">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getmigrationstatus">
     <meta name="author" content="">
-    <title>z_getmigrationstatus - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getmigrationstatus - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getmigrationstatus - Zcash 6.12.1 RPC</h1>
+            <h1>z_getmigrationstatus - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getmigrationstatus ( asOfHeight )
 Returns information about the status of the Sprout to Sapling migration.

--- a/z_getnewaccount.html
+++ b/z_getnewaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnewaccount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnewaccount">
     <meta name="author" content="">
-    <title>z_getnewaccount - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getnewaccount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaccount - Zcash 6.10.0 RPC</h1>
+            <h1>z_getnewaccount - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getnewaccount
 

--- a/z_getnewaccount.html
+++ b/z_getnewaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnewaccount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getnewaccount">
     <meta name="author" content="">
-    <title>z_getnewaccount - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getnewaccount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaccount - Zcash 6.12.1 RPC</h1>
+            <h1>z_getnewaccount - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getnewaccount
 

--- a/z_getnewaccount.html
+++ b/z_getnewaccount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getnewaccount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnewaccount">
     <meta name="author" content="">
-    <title>z_getnewaccount - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getnewaccount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaccount - Zcash 6.2.0 RPC</h1>
+            <h1>z_getnewaccount - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getnewaccount
 

--- a/z_getnewaddress.html
+++ b/z_getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getnewaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnewaddress">
     <meta name="author" content="">
-    <title>z_getnewaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getnewaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaddress - Zcash 6.2.0 RPC</h1>
+            <h1>z_getnewaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getnewaddress ( type )
 

--- a/z_getnewaddress.html
+++ b/z_getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnewaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getnewaddress">
     <meta name="author" content="">
-    <title>z_getnewaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getnewaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaddress - Zcash 6.12.1 RPC</h1>
+            <h1>z_getnewaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getnewaddress ( type )
 

--- a/z_getnewaddress.html
+++ b/z_getnewaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnewaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnewaddress">
     <meta name="author" content="">
-    <title>z_getnewaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getnewaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnewaddress - Zcash 6.10.0 RPC</h1>
+            <h1>z_getnewaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getnewaddress ( type )
 

--- a/z_getnotescount.html
+++ b/z_getnotescount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnotescount">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnotescount">
     <meta name="author" content="">
-    <title>z_getnotescount - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getnotescount - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnotescount - Zcash 6.10.0 RPC</h1>
+            <h1>z_getnotescount - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getnotescount ( minconf asOfHeight )
 

--- a/z_getnotescount.html
+++ b/z_getnotescount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getnotescount">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getnotescount">
     <meta name="author" content="">
-    <title>z_getnotescount - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getnotescount - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnotescount - Zcash 6.12.1 RPC</h1>
+            <h1>z_getnotescount - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getnotescount ( minconf asOfHeight )
 

--- a/z_getnotescount.html
+++ b/z_getnotescount.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getnotescount">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getnotescount">
     <meta name="author" content="">
-    <title>z_getnotescount - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getnotescount - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getnotescount - Zcash 6.2.0 RPC</h1>
+            <h1>z_getnotescount - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getnotescount ( minconf asOfHeight )
 

--- a/z_getoperationresult.html
+++ b/z_getoperationresult.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getoperationresult">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getoperationresult">
     <meta name="author" content="">
-    <title>z_getoperationresult - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getoperationresult - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationresult - Zcash 6.2.0 RPC</h1>
+            <h1>z_getoperationresult - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getoperationresult ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getoperationresult.html
+++ b/z_getoperationresult.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getoperationresult">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getoperationresult">
     <meta name="author" content="">
-    <title>z_getoperationresult - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getoperationresult - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationresult - Zcash 6.12.1 RPC</h1>
+            <h1>z_getoperationresult - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getoperationresult ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getoperationresult.html
+++ b/z_getoperationresult.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getoperationresult">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getoperationresult">
     <meta name="author" content="">
-    <title>z_getoperationresult - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getoperationresult - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationresult - Zcash 6.10.0 RPC</h1>
+            <h1>z_getoperationresult - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getoperationresult ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getoperationstatus.html
+++ b/z_getoperationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getoperationstatus">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getoperationstatus">
     <meta name="author" content="">
-    <title>z_getoperationstatus - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getoperationstatus - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationstatus - Zcash 6.2.0 RPC</h1>
+            <h1>z_getoperationstatus - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getoperationstatus ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getoperationstatus.html
+++ b/z_getoperationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getoperationstatus">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getoperationstatus">
     <meta name="author" content="">
-    <title>z_getoperationstatus - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getoperationstatus - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationstatus - Zcash 6.12.1 RPC</h1>
+            <h1>z_getoperationstatus - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getoperationstatus ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getoperationstatus.html
+++ b/z_getoperationstatus.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getoperationstatus">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getoperationstatus">
     <meta name="author" content="">
-    <title>z_getoperationstatus - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getoperationstatus - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getoperationstatus - Zcash 6.10.0 RPC</h1>
+            <h1>z_getoperationstatus - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getoperationstatus ([&#34;operationid&#34;, ... ]) 
 

--- a/z_getpaymentdisclosure.html
+++ b/z_getpaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getpaymentdisclosure">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getpaymentdisclosure">
     <meta name="author" content="">
-    <title>z_getpaymentdisclosure - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getpaymentdisclosure - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getpaymentdisclosure - Zcash 6.10.0 RPC</h1>
+            <h1>z_getpaymentdisclosure - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getpaymentdisclosure &#34;txid&#34; js_index output_index (&#34;message&#34;) 
 

--- a/z_getpaymentdisclosure.html
+++ b/z_getpaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getpaymentdisclosure">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getpaymentdisclosure">
     <meta name="author" content="">
-    <title>z_getpaymentdisclosure - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getpaymentdisclosure - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getpaymentdisclosure - Zcash 6.2.0 RPC</h1>
+            <h1>z_getpaymentdisclosure - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getpaymentdisclosure &#34;txid&#34; js_index output_index (&#34;message&#34;) 
 

--- a/z_getpaymentdisclosure.html
+++ b/z_getpaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getpaymentdisclosure">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getpaymentdisclosure">
     <meta name="author" content="">
-    <title>z_getpaymentdisclosure - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getpaymentdisclosure - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getpaymentdisclosure - Zcash 6.12.1 RPC</h1>
+            <h1>z_getpaymentdisclosure - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getpaymentdisclosure &#34;txid&#34; js_index output_index (&#34;message&#34;) 
 

--- a/z_getsubtreesbyindex.html
+++ b/z_getsubtreesbyindex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_getsubtreesbyindex">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getsubtreesbyindex">
     <meta name="author" content="">
-    <title>z_getsubtreesbyindex - Zcash 6.2.0 RPC Docs</title>
+    <title>z_getsubtreesbyindex - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getsubtreesbyindex - Zcash 6.2.0 RPC</h1>
+            <h1>z_getsubtreesbyindex - Zcash 6.10.0 RPC</h1>
           
             <pre>z_getsubtreesbyindex &#34;pool&#34; start_index ( limit )
 Returns roots of subtrees of the given pool&#39;s note commitment tree. Each value returned

--- a/z_getsubtreesbyindex.html
+++ b/z_getsubtreesbyindex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_getsubtreesbyindex">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getsubtreesbyindex">
     <meta name="author" content="">
-    <title>z_getsubtreesbyindex - Zcash 6.10.0 RPC Docs</title>
+    <title>z_getsubtreesbyindex - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getsubtreesbyindex - Zcash 6.10.0 RPC</h1>
+            <h1>z_getsubtreesbyindex - Zcash 6.12.1 RPC</h1>
           
             <pre>z_getsubtreesbyindex &#34;pool&#34; start_index ( limit )
 Returns roots of subtrees of the given pool&#39;s note commitment tree. Each value returned

--- a/z_getsubtreesbyindex.html
+++ b/z_getsubtreesbyindex.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_getsubtreesbyindex">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_getsubtreesbyindex">
     <meta name="author" content="">
-    <title>z_getsubtreesbyindex - Zcash 6.12.1 RPC Docs</title>
+    <title>z_getsubtreesbyindex - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_getsubtreesbyindex - Zcash 6.12.1 RPC</h1>
+            <h1>z_getsubtreesbyindex - Zcash 6.12.2 RPC</h1>
           
             <pre>z_getsubtreesbyindex &#34;pool&#34; start_index ( limit )
 Returns roots of subtrees of the given pool&#39;s note commitment tree. Each value returned

--- a/z_gettotalbalance.html
+++ b/z_gettotalbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_gettotalbalance">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_gettotalbalance">
     <meta name="author" content="">
-    <title>z_gettotalbalance - Zcash 6.12.1 RPC Docs</title>
+    <title>z_gettotalbalance - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettotalbalance - Zcash 6.12.1 RPC</h1>
+            <h1>z_gettotalbalance - Zcash 6.12.2 RPC</h1>
           
             <pre>z_gettotalbalance ( minconf includeWatchonly )
 

--- a/z_gettotalbalance.html
+++ b/z_gettotalbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_gettotalbalance">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_gettotalbalance">
     <meta name="author" content="">
-    <title>z_gettotalbalance - Zcash 6.2.0 RPC Docs</title>
+    <title>z_gettotalbalance - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettotalbalance - Zcash 6.2.0 RPC</h1>
+            <h1>z_gettotalbalance - Zcash 6.10.0 RPC</h1>
           
             <pre>z_gettotalbalance ( minconf includeWatchonly )
 

--- a/z_gettotalbalance.html
+++ b/z_gettotalbalance.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_gettotalbalance">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_gettotalbalance">
     <meta name="author" content="">
-    <title>z_gettotalbalance - Zcash 6.10.0 RPC Docs</title>
+    <title>z_gettotalbalance - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettotalbalance - Zcash 6.10.0 RPC</h1>
+            <h1>z_gettotalbalance - Zcash 6.12.1 RPC</h1>
           
             <pre>z_gettotalbalance ( minconf includeWatchonly )
 

--- a/z_gettreestate.html
+++ b/z_gettreestate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_gettreestate">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_gettreestate">
     <meta name="author" content="">
-    <title>z_gettreestate - Zcash 6.2.0 RPC Docs</title>
+    <title>z_gettreestate - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettreestate - Zcash 6.2.0 RPC</h1>
+            <h1>z_gettreestate - Zcash 6.10.0 RPC</h1>
           
             <pre>z_gettreestate &#34;hash|height&#34;
 Return information about the given block&#39;s tree state.

--- a/z_gettreestate.html
+++ b/z_gettreestate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_gettreestate">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_gettreestate">
     <meta name="author" content="">
-    <title>z_gettreestate - Zcash 6.12.1 RPC Docs</title>
+    <title>z_gettreestate - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettreestate - Zcash 6.12.1 RPC</h1>
+            <h1>z_gettreestate - Zcash 6.12.2 RPC</h1>
           
             <pre>z_gettreestate &#34;hash|height&#34;
 Return information about the given block&#39;s tree state.

--- a/z_gettreestate.html
+++ b/z_gettreestate.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_gettreestate">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_gettreestate">
     <meta name="author" content="">
-    <title>z_gettreestate - Zcash 6.10.0 RPC Docs</title>
+    <title>z_gettreestate - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_gettreestate - Zcash 6.10.0 RPC</h1>
+            <h1>z_gettreestate - Zcash 6.12.1 RPC</h1>
           
             <pre>z_gettreestate &#34;hash|height&#34;
 Return information about the given block&#39;s tree state.

--- a/z_importkey.html
+++ b/z_importkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importkey">
     <meta name="author" content="">
-    <title>z_importkey - Zcash 6.10.0 RPC Docs</title>
+    <title>z_importkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importkey - Zcash 6.10.0 RPC</h1>
+            <h1>z_importkey - Zcash 6.12.1 RPC</h1>
           
             <pre>z_importkey &#34;zkey&#34; ( rescan startHeight )
 

--- a/z_importkey.html
+++ b/z_importkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_importkey">
     <meta name="author" content="">
-    <title>z_importkey - Zcash 6.12.1 RPC Docs</title>
+    <title>z_importkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importkey - Zcash 6.12.1 RPC</h1>
+            <h1>z_importkey - Zcash 6.12.2 RPC</h1>
           
             <pre>z_importkey &#34;zkey&#34; ( rescan startHeight )
 

--- a/z_importkey.html
+++ b/z_importkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_importkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importkey">
     <meta name="author" content="">
-    <title>z_importkey - Zcash 6.2.0 RPC Docs</title>
+    <title>z_importkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importkey - Zcash 6.2.0 RPC</h1>
+            <h1>z_importkey - Zcash 6.10.0 RPC</h1>
           
             <pre>z_importkey &#34;zkey&#34; ( rescan startHeight )
 

--- a/z_importviewingkey.html
+++ b/z_importviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importviewingkey">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_importviewingkey">
     <meta name="author" content="">
-    <title>z_importviewingkey - Zcash 6.12.1 RPC Docs</title>
+    <title>z_importviewingkey - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importviewingkey - Zcash 6.12.1 RPC</h1>
+            <h1>z_importviewingkey - Zcash 6.12.2 RPC</h1>
           
             <pre>z_importviewingkey &#34;vkey&#34; ( rescan startHeight )
 

--- a/z_importviewingkey.html
+++ b/z_importviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_importviewingkey">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importviewingkey">
     <meta name="author" content="">
-    <title>z_importviewingkey - Zcash 6.2.0 RPC Docs</title>
+    <title>z_importviewingkey - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importviewingkey - Zcash 6.2.0 RPC</h1>
+            <h1>z_importviewingkey - Zcash 6.10.0 RPC</h1>
           
             <pre>z_importviewingkey &#34;vkey&#34; ( rescan startHeight )
 

--- a/z_importviewingkey.html
+++ b/z_importviewingkey.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importviewingkey">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importviewingkey">
     <meta name="author" content="">
-    <title>z_importviewingkey - Zcash 6.10.0 RPC Docs</title>
+    <title>z_importviewingkey - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importviewingkey - Zcash 6.10.0 RPC</h1>
+            <h1>z_importviewingkey - Zcash 6.12.1 RPC</h1>
           
             <pre>z_importviewingkey &#34;vkey&#34; ( rescan startHeight )
 

--- a/z_importwallet.html
+++ b/z_importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importwallet">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_importwallet">
     <meta name="author" content="">
-    <title>z_importwallet - Zcash 6.12.1 RPC Docs</title>
+    <title>z_importwallet - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importwallet - Zcash 6.12.1 RPC</h1>
+            <h1>z_importwallet - Zcash 6.12.2 RPC</h1>
           
             <pre>z_importwallet &#34;filename&#34;
 

--- a/z_importwallet.html
+++ b/z_importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importwallet">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_importwallet">
     <meta name="author" content="">
-    <title>z_importwallet - Zcash 6.10.0 RPC Docs</title>
+    <title>z_importwallet - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importwallet - Zcash 6.10.0 RPC</h1>
+            <h1>z_importwallet - Zcash 6.12.1 RPC</h1>
           
             <pre>z_importwallet &#34;filename&#34;
 

--- a/z_importwallet.html
+++ b/z_importwallet.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_importwallet">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_importwallet">
     <meta name="author" content="">
-    <title>z_importwallet - Zcash 6.2.0 RPC Docs</title>
+    <title>z_importwallet - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_importwallet - Zcash 6.2.0 RPC</h1>
+            <h1>z_importwallet - Zcash 6.10.0 RPC</h1>
           
             <pre>z_importwallet &#34;filename&#34;
 

--- a/z_listaccounts.html
+++ b/z_listaccounts.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listaccounts">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listaccounts">
     <meta name="author" content="">
-    <title>z_listaccounts - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listaccounts - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaccounts - Zcash 6.10.0 RPC</h1>
+            <h1>z_listaccounts - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listaccounts
 

--- a/z_listaccounts.html
+++ b/z_listaccounts.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listaccounts">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listaccounts">
     <meta name="author" content="">
-    <title>z_listaccounts - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listaccounts - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaccounts - Zcash 6.2.0 RPC</h1>
+            <h1>z_listaccounts - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listaccounts
 

--- a/z_listaccounts.html
+++ b/z_listaccounts.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listaccounts">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listaccounts">
     <meta name="author" content="">
-    <title>z_listaccounts - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listaccounts - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaccounts - Zcash 6.12.1 RPC</h1>
+            <h1>z_listaccounts - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listaccounts
 

--- a/z_listaddresses.html
+++ b/z_listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listaddresses">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listaddresses">
     <meta name="author" content="">
-    <title>z_listaddresses - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listaddresses - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaddresses - Zcash 6.10.0 RPC</h1>
+            <h1>z_listaddresses - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listaddresses ( includeWatchonly )
 

--- a/z_listaddresses.html
+++ b/z_listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listaddresses">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listaddresses">
     <meta name="author" content="">
-    <title>z_listaddresses - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listaddresses - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaddresses - Zcash 6.12.1 RPC</h1>
+            <h1>z_listaddresses - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listaddresses ( includeWatchonly )
 

--- a/z_listaddresses.html
+++ b/z_listaddresses.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listaddresses">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listaddresses">
     <meta name="author" content="">
-    <title>z_listaddresses - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listaddresses - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listaddresses - Zcash 6.2.0 RPC</h1>
+            <h1>z_listaddresses - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listaddresses ( includeWatchonly )
 

--- a/z_listoperationids.html
+++ b/z_listoperationids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listoperationids">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listoperationids">
     <meta name="author" content="">
-    <title>z_listoperationids - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listoperationids - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listoperationids - Zcash 6.10.0 RPC</h1>
+            <h1>z_listoperationids - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listoperationids
 

--- a/z_listoperationids.html
+++ b/z_listoperationids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listoperationids">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listoperationids">
     <meta name="author" content="">
-    <title>z_listoperationids - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listoperationids - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listoperationids - Zcash 6.12.1 RPC</h1>
+            <h1>z_listoperationids - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listoperationids
 

--- a/z_listoperationids.html
+++ b/z_listoperationids.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listoperationids">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listoperationids">
     <meta name="author" content="">
-    <title>z_listoperationids - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listoperationids - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listoperationids - Zcash 6.2.0 RPC</h1>
+            <h1>z_listoperationids - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listoperationids
 

--- a/z_listreceivedbyaddress.html
+++ b/z_listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listreceivedbyaddress">
     <meta name="author" content="">
-    <title>z_listreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listreceivedbyaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listreceivedbyaddress - Zcash 6.12.1 RPC</h1>
+            <h1>z_listreceivedbyaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listreceivedbyaddress &#34;address&#34; ( minconf asOfHeight )
 

--- a/z_listreceivedbyaddress.html
+++ b/z_listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listreceivedbyaddress">
     <meta name="author" content="">
-    <title>z_listreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listreceivedbyaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listreceivedbyaddress - Zcash 6.10.0 RPC</h1>
+            <h1>z_listreceivedbyaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listreceivedbyaddress &#34;address&#34; ( minconf asOfHeight )
 

--- a/z_listreceivedbyaddress.html
+++ b/z_listreceivedbyaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listreceivedbyaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listreceivedbyaddress">
     <meta name="author" content="">
-    <title>z_listreceivedbyaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listreceivedbyaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listreceivedbyaddress - Zcash 6.2.0 RPC</h1>
+            <h1>z_listreceivedbyaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listreceivedbyaddress &#34;address&#34; ( minconf asOfHeight )
 

--- a/z_listunifiedreceivers.html
+++ b/z_listunifiedreceivers.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listunifiedreceivers">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listunifiedreceivers">
     <meta name="author" content="">
-    <title>z_listunifiedreceivers - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listunifiedreceivers - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunifiedreceivers - Zcash 6.2.0 RPC</h1>
+            <h1>z_listunifiedreceivers - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listunifiedreceivers unified_address
 

--- a/z_listunifiedreceivers.html
+++ b/z_listunifiedreceivers.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listunifiedreceivers">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listunifiedreceivers">
     <meta name="author" content="">
-    <title>z_listunifiedreceivers - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listunifiedreceivers - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunifiedreceivers - Zcash 6.10.0 RPC</h1>
+            <h1>z_listunifiedreceivers - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listunifiedreceivers unified_address
 

--- a/z_listunifiedreceivers.html
+++ b/z_listunifiedreceivers.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listunifiedreceivers">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listunifiedreceivers">
     <meta name="author" content="">
-    <title>z_listunifiedreceivers - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listunifiedreceivers - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunifiedreceivers - Zcash 6.12.1 RPC</h1>
+            <h1>z_listunifiedreceivers - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listunifiedreceivers unified_address
 

--- a/z_listunspent.html
+++ b/z_listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listunspent">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_listunspent">
     <meta name="author" content="">
-    <title>z_listunspent - Zcash 6.12.1 RPC Docs</title>
+    <title>z_listunspent - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunspent - Zcash 6.12.1 RPC</h1>
+            <h1>z_listunspent - Zcash 6.12.2 RPC</h1>
           
             <pre>z_listunspent ( minconf maxconf includeWatchonly [&#34;zaddr&#34;,...] asOfHeight )
 

--- a/z_listunspent.html
+++ b/z_listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listunspent">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_listunspent">
     <meta name="author" content="">
-    <title>z_listunspent - Zcash 6.10.0 RPC Docs</title>
+    <title>z_listunspent - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunspent - Zcash 6.10.0 RPC</h1>
+            <h1>z_listunspent - Zcash 6.12.1 RPC</h1>
           
             <pre>z_listunspent ( minconf maxconf includeWatchonly [&#34;zaddr&#34;,...] asOfHeight )
 

--- a/z_listunspent.html
+++ b/z_listunspent.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_listunspent">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_listunspent">
     <meta name="author" content="">
-    <title>z_listunspent - Zcash 6.2.0 RPC Docs</title>
+    <title>z_listunspent - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_listunspent - Zcash 6.2.0 RPC</h1>
+            <h1>z_listunspent - Zcash 6.10.0 RPC</h1>
           
             <pre>z_listunspent ( minconf maxconf includeWatchonly [&#34;zaddr&#34;,...] asOfHeight )
 

--- a/z_mergetoaddress.html
+++ b/z_mergetoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_mergetoaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_mergetoaddress">
     <meta name="author" content="">
-    <title>z_mergetoaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>z_mergetoaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_mergetoaddress - Zcash 6.10.0 RPC</h1>
+            <h1>z_mergetoaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>z_mergetoaddress [&#34;fromaddress&#34;, ... ] &#34;toaddress&#34; ( fee ) ( transparent_limit ) ( shielded_limit ) ( memo ) ( privacyPolicy )
 

--- a/z_mergetoaddress.html
+++ b/z_mergetoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_mergetoaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_mergetoaddress">
     <meta name="author" content="">
-    <title>z_mergetoaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>z_mergetoaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_mergetoaddress - Zcash 6.2.0 RPC</h1>
+            <h1>z_mergetoaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>z_mergetoaddress [&#34;fromaddress&#34;, ... ] &#34;toaddress&#34; ( fee ) ( transparent_limit ) ( shielded_limit ) ( memo ) ( privacyPolicy )
 

--- a/z_mergetoaddress.html
+++ b/z_mergetoaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_mergetoaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_mergetoaddress">
     <meta name="author" content="">
-    <title>z_mergetoaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>z_mergetoaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_mergetoaddress - Zcash 6.12.1 RPC</h1>
+            <h1>z_mergetoaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>z_mergetoaddress [&#34;fromaddress&#34;, ... ] &#34;toaddress&#34; ( fee ) ( transparent_limit ) ( shielded_limit ) ( memo ) ( privacyPolicy )
 

--- a/z_sendmany.html
+++ b/z_sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_sendmany">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_sendmany">
     <meta name="author" content="">
-    <title>z_sendmany - Zcash 6.10.0 RPC Docs</title>
+    <title>z_sendmany - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_sendmany - Zcash 6.10.0 RPC</h1>
+            <h1>z_sendmany - Zcash 6.12.1 RPC</h1>
           
             <pre>z_sendmany &#34;fromaddress&#34; [{&#34;address&#34;:... ,&#34;amount&#34;:...},...] ( minconf ) ( fee ) ( privacyPolicy )
 

--- a/z_sendmany.html
+++ b/z_sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_sendmany">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_sendmany">
     <meta name="author" content="">
-    <title>z_sendmany - Zcash 6.12.1 RPC Docs</title>
+    <title>z_sendmany - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_sendmany - Zcash 6.12.1 RPC</h1>
+            <h1>z_sendmany - Zcash 6.12.2 RPC</h1>
           
             <pre>z_sendmany &#34;fromaddress&#34; [{&#34;address&#34;:... ,&#34;amount&#34;:...},...] ( minconf ) ( fee ) ( privacyPolicy )
 

--- a/z_sendmany.html
+++ b/z_sendmany.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_sendmany">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_sendmany">
     <meta name="author" content="">
-    <title>z_sendmany - Zcash 6.2.0 RPC Docs</title>
+    <title>z_sendmany - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_sendmany - Zcash 6.2.0 RPC</h1>
+            <h1>z_sendmany - Zcash 6.10.0 RPC</h1>
           
             <pre>z_sendmany &#34;fromaddress&#34; [{&#34;address&#34;:... ,&#34;amount&#34;:...},...] ( minconf ) ( fee ) ( privacyPolicy )
 

--- a/z_setmigration.html
+++ b/z_setmigration.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_setmigration">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_setmigration">
     <meta name="author" content="">
-    <title>z_setmigration - Zcash 6.12.1 RPC Docs</title>
+    <title>z_setmigration - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_setmigration - Zcash 6.12.1 RPC</h1>
+            <h1>z_setmigration - Zcash 6.12.2 RPC</h1>
           
             <pre>z_setmigration enabled
 When enabled the Sprout to Sapling migration will attempt to migrate all funds from this wallet’s

--- a/z_setmigration.html
+++ b/z_setmigration.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_setmigration">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_setmigration">
     <meta name="author" content="">
-    <title>z_setmigration - Zcash 6.10.0 RPC Docs</title>
+    <title>z_setmigration - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_setmigration - Zcash 6.10.0 RPC</h1>
+            <h1>z_setmigration - Zcash 6.12.1 RPC</h1>
           
             <pre>z_setmigration enabled
 When enabled the Sprout to Sapling migration will attempt to migrate all funds from this wallet’s
@@ -38,8 +38,8 @@ Sprout addresses to either the address for Sapling account 0 or the address spec
 &#39;-migrationdestaddress&#39;.
 
 This migration is designed to minimize information leakage. As a result for wallets with a significant
-Sprout balance, this process may take several weeks. The migration works by sending, up to 5, as many
-transactions as possible whenever the blockchain reaches a height equal to 499 modulo 500. The transaction
+Sprout balance, this process may take several hours. The migration works by sending, up to 5, as many
+transactions as possible whenever the blockchain reaches a height equal to 99 modulo 100. The transaction
 amounts are picked according to the random distribution specified in ZIP 308. The migration will end once
 the wallet’s Sprout balance is below 0.01 ZEC.
 

--- a/z_setmigration.html
+++ b/z_setmigration.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_setmigration">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_setmigration">
     <meta name="author" content="">
-    <title>z_setmigration - Zcash 6.2.0 RPC Docs</title>
+    <title>z_setmigration - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_setmigration - Zcash 6.2.0 RPC</h1>
+            <h1>z_setmigration - Zcash 6.10.0 RPC</h1>
           
             <pre>z_setmigration enabled
 When enabled the Sprout to Sapling migration will attempt to migrate all funds from this wallet’s

--- a/z_shieldcoinbase.html
+++ b/z_shieldcoinbase.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_shieldcoinbase">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_shieldcoinbase">
     <meta name="author" content="">
-    <title>z_shieldcoinbase - Zcash 6.10.0 RPC Docs</title>
+    <title>z_shieldcoinbase - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_shieldcoinbase - Zcash 6.10.0 RPC</h1>
+            <h1>z_shieldcoinbase - Zcash 6.12.1 RPC</h1>
           
             <pre>z_shieldcoinbase &#34;fromaddress&#34; &#34;tozaddress&#34; ( fee ) ( limit ) ( memo ) ( privacyPolicy )
 

--- a/z_shieldcoinbase.html
+++ b/z_shieldcoinbase.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_shieldcoinbase">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_shieldcoinbase">
     <meta name="author" content="">
-    <title>z_shieldcoinbase - Zcash 6.2.0 RPC Docs</title>
+    <title>z_shieldcoinbase - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_shieldcoinbase - Zcash 6.2.0 RPC</h1>
+            <h1>z_shieldcoinbase - Zcash 6.10.0 RPC</h1>
           
             <pre>z_shieldcoinbase &#34;fromaddress&#34; &#34;tozaddress&#34; ( fee ) ( limit ) ( memo ) ( privacyPolicy )
 

--- a/z_shieldcoinbase.html
+++ b/z_shieldcoinbase.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_shieldcoinbase">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_shieldcoinbase">
     <meta name="author" content="">
-    <title>z_shieldcoinbase - Zcash 6.12.1 RPC Docs</title>
+    <title>z_shieldcoinbase - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_shieldcoinbase - Zcash 6.12.1 RPC</h1>
+            <h1>z_shieldcoinbase - Zcash 6.12.2 RPC</h1>
           
             <pre>z_shieldcoinbase &#34;fromaddress&#34; &#34;tozaddress&#34; ( fee ) ( limit ) ( memo ) ( privacyPolicy )
 

--- a/z_validateaddress.html
+++ b/z_validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_validateaddress">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_validateaddress">
     <meta name="author" content="">
-    <title>z_validateaddress - Zcash 6.10.0 RPC Docs</title>
+    <title>z_validateaddress - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validateaddress - Zcash 6.10.0 RPC</h1>
+            <h1>z_validateaddress - Zcash 6.12.1 RPC</h1>
           
             <pre>z_validateaddress &#34;address&#34;
 

--- a/z_validateaddress.html
+++ b/z_validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_validateaddress">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_validateaddress">
     <meta name="author" content="">
-    <title>z_validateaddress - Zcash 6.2.0 RPC Docs</title>
+    <title>z_validateaddress - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validateaddress - Zcash 6.2.0 RPC</h1>
+            <h1>z_validateaddress - Zcash 6.10.0 RPC</h1>
           
             <pre>z_validateaddress &#34;address&#34;
 

--- a/z_validateaddress.html
+++ b/z_validateaddress.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_validateaddress">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_validateaddress">
     <meta name="author" content="">
-    <title>z_validateaddress - Zcash 6.12.1 RPC Docs</title>
+    <title>z_validateaddress - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validateaddress - Zcash 6.12.1 RPC</h1>
+            <h1>z_validateaddress - Zcash 6.12.2 RPC</h1>
           
             <pre>z_validateaddress &#34;address&#34;
 

--- a/z_validatepaymentdisclosure.html
+++ b/z_validatepaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_validatepaymentdisclosure">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_validatepaymentdisclosure">
     <meta name="author" content="">
-    <title>z_validatepaymentdisclosure - Zcash 6.12.1 RPC Docs</title>
+    <title>z_validatepaymentdisclosure - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validatepaymentdisclosure - Zcash 6.12.1 RPC</h1>
+            <h1>z_validatepaymentdisclosure - Zcash 6.12.2 RPC</h1>
           
             <pre>z_validatepaymentdisclosure &#34;paymentdisclosure&#34;
 

--- a/z_validatepaymentdisclosure.html
+++ b/z_validatepaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_validatepaymentdisclosure">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_validatepaymentdisclosure">
     <meta name="author" content="">
-    <title>z_validatepaymentdisclosure - Zcash 6.10.0 RPC Docs</title>
+    <title>z_validatepaymentdisclosure - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validatepaymentdisclosure - Zcash 6.10.0 RPC</h1>
+            <h1>z_validatepaymentdisclosure - Zcash 6.12.1 RPC</h1>
           
             <pre>z_validatepaymentdisclosure &#34;paymentdisclosure&#34;
 

--- a/z_validatepaymentdisclosure.html
+++ b/z_validatepaymentdisclosure.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_validatepaymentdisclosure">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_validatepaymentdisclosure">
     <meta name="author" content="">
-    <title>z_validatepaymentdisclosure - Zcash 6.2.0 RPC Docs</title>
+    <title>z_validatepaymentdisclosure - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_validatepaymentdisclosure - Zcash 6.2.0 RPC</h1>
+            <h1>z_validatepaymentdisclosure - Zcash 6.10.0 RPC</h1>
           
             <pre>z_validatepaymentdisclosure &#34;paymentdisclosure&#34;
 

--- a/z_viewtransaction.html
+++ b/z_viewtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - z_viewtransaction">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_viewtransaction">
     <meta name="author" content="">
-    <title>z_viewtransaction - Zcash 6.2.0 RPC Docs</title>
+    <title>z_viewtransaction - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_viewtransaction - Zcash 6.2.0 RPC</h1>
+            <h1>z_viewtransaction - Zcash 6.10.0 RPC</h1>
           
             <pre>z_viewtransaction &#34;txid&#34;
 

--- a/z_viewtransaction.html
+++ b/z_viewtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - z_viewtransaction">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_viewtransaction">
     <meta name="author" content="">
-    <title>z_viewtransaction - Zcash 6.10.0 RPC Docs</title>
+    <title>z_viewtransaction - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_viewtransaction - Zcash 6.10.0 RPC</h1>
+            <h1>z_viewtransaction - Zcash 6.12.1 RPC</h1>
           
             <pre>z_viewtransaction &#34;txid&#34;
 

--- a/z_viewtransaction.html
+++ b/z_viewtransaction.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - z_viewtransaction">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - z_viewtransaction">
     <meta name="author" content="">
-    <title>z_viewtransaction - Zcash 6.12.1 RPC Docs</title>
+    <title>z_viewtransaction - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>z_viewtransaction - Zcash 6.12.1 RPC</h1>
+            <h1>z_viewtransaction - Zcash 6.12.2 RPC</h1>
           
             <pre>z_viewtransaction &#34;txid&#34;
 

--- a/zcbenchmark.html
+++ b/zcbenchmark.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - zcbenchmark">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - zcbenchmark">
     <meta name="author" content="">
-    <title>zcbenchmark - Zcash 6.12.1 RPC Docs</title>
+    <title>zcbenchmark - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcbenchmark - Zcash 6.12.1 RPC</h1>
+            <h1>zcbenchmark - Zcash 6.12.2 RPC</h1>
           
             <pre>zcbenchmark benchmarktype samplecount
 

--- a/zcbenchmark.html
+++ b/zcbenchmark.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - zcbenchmark">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - zcbenchmark">
     <meta name="author" content="">
-    <title>zcbenchmark - Zcash 6.2.0 RPC Docs</title>
+    <title>zcbenchmark - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcbenchmark - Zcash 6.2.0 RPC</h1>
+            <h1>zcbenchmark - Zcash 6.10.0 RPC</h1>
           
             <pre>zcbenchmark benchmarktype samplecount
 

--- a/zcbenchmark.html
+++ b/zcbenchmark.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - zcbenchmark">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - zcbenchmark">
     <meta name="author" content="">
-    <title>zcbenchmark - Zcash 6.10.0 RPC Docs</title>
+    <title>zcbenchmark - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcbenchmark - Zcash 6.10.0 RPC</h1>
+            <h1>zcbenchmark - Zcash 6.12.1 RPC</h1>
           
             <pre>zcbenchmark benchmarktype samplecount
 

--- a/zcsamplejoinsplit.html
+++ b/zcsamplejoinsplit.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.12.1 RPC Docs - zcsamplejoinsplit">
+    <meta name="description" content="Zcash 6.12.2 RPC Docs - zcsamplejoinsplit">
     <meta name="author" content="">
-    <title>zcsamplejoinsplit - Zcash 6.12.1 RPC Docs</title>
+    <title>zcsamplejoinsplit - Zcash 6.12.2 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.2 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcsamplejoinsplit - Zcash 6.12.1 RPC</h1>
+            <h1>zcsamplejoinsplit - Zcash 6.12.2 RPC</h1>
           
             <pre>zcsamplejoinsplit
 

--- a/zcsamplejoinsplit.html
+++ b/zcsamplejoinsplit.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.3.0 RPC Docs - zcsamplejoinsplit">
+    <meta name="description" content="Zcash 6.10.0 RPC Docs - zcsamplejoinsplit">
     <meta name="author" content="">
-    <title>zcsamplejoinsplit - Zcash 6.2.0 RPC Docs</title>
+    <title>zcsamplejoinsplit - Zcash 6.10.0 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.2.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcsamplejoinsplit - Zcash 6.2.0 RPC</h1>
+            <h1>zcsamplejoinsplit - Zcash 6.10.0 RPC</h1>
           
             <pre>zcsamplejoinsplit
 

--- a/zcsamplejoinsplit.html
+++ b/zcsamplejoinsplit.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=1200px, shrink-to-fit=yes">
-    <meta name="description" content="Zcash 6.10.0 RPC Docs - zcsamplejoinsplit">
+    <meta name="description" content="Zcash 6.12.1 RPC Docs - zcsamplejoinsplit">
     <meta name="author" content="">
-    <title>zcsamplejoinsplit - Zcash 6.10.0 RPC Docs</title>
+    <title>zcsamplejoinsplit - Zcash 6.12.1 RPC Docs</title>
     <link href="./bootstrap.min.css" rel="stylesheet">
   </head>
   <style>
@@ -23,14 +23,14 @@
 
 
     <nav class="navbar  navbar-dark bg-dark ">
-      <a class="navbar-brand" href="/">Zcash 6.10.0 RPC Docs</a>
+      <a class="navbar-brand" href="/">Zcash 6.12.1 RPC Docs</a>
     </nav>
 
     <main role="main" class="container-fluid" style="margin-top: 1pc;">
 
       <div class="row">
         <div class="col-8 col-lg-9 col-xl-10">
-            <h1>zcsamplejoinsplit - Zcash 6.10.0 RPC</h1>
+            <h1>zcsamplejoinsplit - Zcash 6.12.1 RPC</h1>
           
             <pre>zcsamplejoinsplit
 


### PR DESCRIPTION
Update RPC documentation to zcash v6.12.2.

## Changes

- **Version bumped** across all HTML files (v6.12.1 → v6.12.2)
- **No RPC interface changes** between v6.12.1 and v6.12.2

v6.12.2 is a security-fix release. The only RPC-layer code changes are in error-propagation for `decoderawtransaction`, `sendrawtransaction`, and `fundrawtransaction` — these now return the decoder's exception message instead of a generic "TX decode failed" when Sapling-invariant checks reject malformed transactions. No help text changed, no methods were added or removed, so this PR is purely a version-string bump over the content previously prepared for [v6.12.1](https://github.com/zcash/zcash/releases/tag/v6.12.1) in #23.

This supersedes #23. Please close #23 in favor of this one.